### PR TITLE
Allow initialization after VimEnter

### DIFF
--- a/autoload/markbar/MarkbarModel.vim
+++ b/autoload/markbar/MarkbarModel.vim
@@ -50,6 +50,10 @@ function! markbar#MarkbarModel#get() abort
             \ function('markbar#MarkbarModel#updateCurrentAndGlobal'),
     \ }
 
+    if v:vim_did_enter
+      call g:markbar_model.pushNewBuffer(markbar#helpers#GetOpenBuffers())
+    endif
+
     augroup markbar_model_update
         au!
         autocmd VimEnter * call g:markbar_model.pushNewBuffer(markbar#helpers#GetOpenBuffers())


### PR DESCRIPTION
# Problem
First attempt to open the markbar fails if vim-markbar is initialized after VimEnter.

# How to Reproduce
Using the configuration below, press `<Leader>tm`:

```vim
call plug#begin('~/.vim/plugged')
Plug 'Yilin-Yang/vim-markbar', {'on': [
 \ '<Plug>OpenMarkbarPeekabooApostrophe', '<Plug>OpenMarkbarPeekabooBacktick',
 \ '<Plug>ToggleMarkbar' ]}
call plug#end()

nmap <Leader>tm <Plug>ToggleMarkbar
nmap <Leader>' <Plug>OpenMarkbarPeekabooApostrophe
nmap <Leader>` <Plug>OpenMarkbarPeekabooBacktick

let g:markbar_peekaboo_apostrophe_mapping='<Nop>'
let g:markbar_peekaboo_backtick_mapping='<Nop>'
```