### PR TITLE
Respect user's &foldopen settings when jumping from the markbar

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# https://editorconfig.org/
+
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+
+[Makefile]
+indent_style = tab
+
+[*.vim]
+indent_size = 4
+
+[*.yml]
+indent_size = 2

--- a/.travis_vimrc
+++ b/.travis_vimrc
@@ -17,5 +17,6 @@ filetype plugin indent on
 syntax enable
 set autoread
 set hidden
+set foldcolumn=1
 
 map <Leader>m <Plug>ToggleMarkbar

--- a/autoload/markbar/MarkbarView.vim
+++ b/autoload/markbar/MarkbarView.vim
@@ -283,6 +283,10 @@ function! markbar#MarkbarView#_goToMark(mark, goto_exact) abort dict
         return
     endtry
 
+    if markbar#settings#foldopen()
+        normal! zv
+    endif
+
     if markbar#settings#CloseAfterGoTo()
         call l:self.closeMarkbar()
     endif

--- a/autoload/markbar/settings.vim
+++ b/autoload/markbar/settings.vim
@@ -42,6 +42,28 @@ function! markbar#settings#MarksToDisplay() abort
     return g:markbar_marks_to_display
 endfunction
 
+" RETURNS:  (v:t_bool)      Whether to open the fold(s) in which a mark is
+"                           located, if any.
+function! markbar#settings#foldopen() abort
+    if !exists('g:markbar_foldopen')
+        let g:markbar_foldopen = v:false
+        let l:foldopen_values = split(&foldopen, ',')
+        for l:open_on in l:foldopen_values
+            if l:open_on !=# 'mark'
+                continue
+            endif
+            let g:markbar_foldopen = v:true
+            break
+        endfor
+    endif
+    call s:AssertType(
+        \ g:markbar_foldopen,
+        \ v:t_bool,
+        \ 'g:markbar_foldopen'
+    \ )
+    return g:markbar_foldopen
+endfunction
+
 " RETURNS:  (v:t_bool)      Whether to open markbars as vertical splits
 "                           (`v:true`) or horizontal splits (`v:false`).
 function! markbar#settings#MarkbarOpenVertical() abort

--- a/doc/vim-markbar.txt
+++ b/doc/vim-markbar.txt
@@ -111,6 +111,19 @@ For options unique to the "peekaboo" markbar, see |vim-markbar-peekaboo-options|
 
     Marks not listed in the string above are not listed in the markbar.
 
+*g:markbar_foldopen*                                     |(v:t_bool)|
+    `Default Value`: (set from the 'foldopen' option, see `:help fdo`)
+
+    Whether to expand folds when jumping to a mark located inside of a closed
+    |fold|. When enabled, mimics the behavior of `set foldopen=mark` by opening
+    "just enough" folds so that the mark's line is visible.
+
+    If 'foldopen' contains `"mark"` (which it should, by default), this
+    will default to `v:true`. Otherwise, this will default to `v:false`.
+
+    Note that this variable is not synchronized to 'foldopen': it will not
+    update if 'foldopen' is changed after *g:markbar_foldopen* is initialized.
+
 *g:markbar_open_vertical*                                |(v:t_bool)|
 *g:markbar_peekaboo_open_vertical*
     `Default Value:` `v:true`

--- a/test/foldopen-helpers.vader
+++ b/test/foldopen-helpers.vader
@@ -1,0 +1,120 @@
+Include: load-test-files.vader
+
+Execute (Initialize, Declare Test Helpers):
+
+  function! FoldAtImpl(first_line, last_line) abort
+    execute printf('normal! %dGv%dG', a:first_line, a:last_line)
+    execute "normal! zfzo''"
+  endfunction
+
+  ""
+  " Create a fold spanning the two line numbers given as arguments, inclusive.
+  " The fold will be open after creation, and the cursor will be returned
+  " to its original position.
+  command! -nargs=+ FoldAt call FoldAtImpl(<f-args>)
+
+  function! MarkAtImpl(mark, line) abort
+    execute printf("normal! %dGm%s''", a:line, a:mark)
+  endfunction
+
+  ""
+  " Place a {mark} at the given {line}.
+  command! -nargs=+ MarkAt call MarkAtImpl(<f-args>)
+
+  const g:folds = sort([
+    \ {'foldlevel': 1, 'startline': 2, 'endline': 10},
+    \ {'foldlevel': 2, 'startline': 3, 'endline': 5},
+    \ {'foldlevel': 3, 'startline': 4, 'endline': 5},
+    \ {'foldlevel': 2, 'startline': 7, 'endline': 10},
+    \ {'foldlevel': 3, 'startline': 9, 'endline': 10},
+  \ ], {fold1, fold2 -> fold1.foldlevel - fold2.foldlevel})
+
+  ""
+  " Get a snapshot of folds in the current buffer, and whether or not they'd
+  " "prefer" to be closed or open. Returns a dict between `printf` strings
+  " formatted like `("%d,%d", startline, endline)` and 0, if that fold is open,
+  " and 1, if that fold was closed.
+  "
+  " For instance, given the following fold structure in a three-line buffer:
+  "
+  "     1    (CLOSED)
+  "     |--2 (OPEN)
+  "     |  |
+  "
+  " This function should return:
+  "
+  "     {'1,3': 1, '2,3': 0}
+  "
+  " It is required that `g:folds` be sorted from outermost folds to most deeply
+  " nested folds.
+  "
+  " This will (DESTRUCTIVELY) open all folds and move the cursor.
+  function! GetClosedState() abort
+    let l:ranges_to_closed = {}
+    for l:fold in g:folds
+      let l:ranges_to_closed[printf(
+          \ '%d,%d', l:fold.startline, l:fold.endline)] =
+              \ foldclosed(l:fold.startline) !=# -1
+      execute printf('normal! %dGzo', l:fold.startline)
+    endfor
+    return l:ranges_to_closed
+  endfunction
+
+  function! AssertClosedStateMatches(expected, actual) abort
+    let l:actual = copy(a:actual)
+    let l:expected = copy(a:expected)
+    for [l:range, l:is_closed] in items(l:actual)
+      if !has_key(l:expected, l:range)
+        echoerr printf("Fold from %s doesn't exist in expected: %s",
+            \ l:range, string(l:expected))
+      endif
+      if l:expected[l:range] !=# l:is_closed
+        echoerr printf("Fold from %s had close state %d, but should have had %d",
+            \ l:range, l:is_closed, l:expected[l:range])
+      endif
+      unlet l:actual[l:range]
+      unlet l:expected[l:range]
+    endfor
+    if len(l:expected)
+      echoerr printf('Some expected folds are missing in actual: %s',
+          \ string(l:expected))
+    endif
+  endfunction
+
+  " test cases for helpers
+  call AssertClosedStateMatches({'1,2':0}, {'1,2':0})
+  AssertThrows call AssertClosedStateMatches({'1,2':0}, {'1,2':1})
+  AssertThrows call AssertClosedStateMatches({'1,2':0, '1,3':1}, {'1,2':0})
+  AssertThrows call AssertClosedStateMatches({'1,2':0}, {'1,2':0, '1,3':1})
+
+
+Before (Open Test Buffer, Open All Folds Recursively):
+  edit! 10lines.txt
+  set foldmethod=manual
+  silent! normal! zM
+
+Execute (Set Up Folds and Marks):
+  " Build the following structure of folds:
+  " (line no)  (mark)   (fold)
+  "   1.                0
+  "   2.        a       1--
+  "   3.        b       | 2--
+  "   4.        c       | | |
+  "   5.                | | 3--
+  "   6.        d       |
+  "   7.                | 2--
+  "   8.        e       | | |
+  "   9.                | | 3--
+  "  10.        f       | | | |
+  for g:fold in g:folds
+    execute printf('FoldAt %d %d', g:fold.startline, g:fold.endline)
+  endfor
+
+  MarkAt a 2
+  MarkAt b 3
+  MarkAt c 4
+
+  MarkAt d 6
+
+  MarkAt e 8
+  MarkAt f 10

--- a/test/foldopen-helpers.vader
+++ b/test/foldopen-helpers.vader
@@ -21,13 +21,14 @@ Execute (Initialize, Declare Test Helpers):
   " Place a {mark} at the given {line}.
   command! -nargs=+ MarkAt call MarkAtImpl(<f-args>)
 
-  const g:folds = sort([
+  let g:folds = sort([
     \ {'foldlevel': 1, 'startline': 2, 'endline': 10},
     \ {'foldlevel': 2, 'startline': 3, 'endline': 5},
     \ {'foldlevel': 3, 'startline': 4, 'endline': 5},
     \ {'foldlevel': 2, 'startline': 7, 'endline': 10},
     \ {'foldlevel': 3, 'startline': 9, 'endline': 10},
   \ ], {fold1, fold2 -> fold1.foldlevel - fold2.foldlevel})
+  lockvar! g:folds
 
   ""
   " Get a snapshot of folds in the current buffer, and whether or not they'd

--- a/test/load-test-files.vader
+++ b/test/load-test-files.vader
@@ -18,8 +18,6 @@ Execute (Open Buffers):
       \ . '" not available in PWD!'
   endif
 
-  let s:i = 0
-  while s:i <# len(s:test_files)
-    execute 'normal :edit! ' . s:test_files[s:i] . "\<cr>"
-    let s:i += 1
-  endwhile
+  for s:file in s:test_files
+    execute 'normal :edit! ' . s:file . "\<cr>"
+  endfor

--- a/test/standalone-test-foldopen-init-false.vader
+++ b/test/standalone-test-foldopen-init-false.vader
@@ -1,0 +1,9 @@
+Include: foldopen-helpers.vader
+" see foldopen-helpers.vader for comments and documentation
+" There is no test-foldopen-init-true because the default value of foldopen
+" should include mark.
+
+Execute (Remove "mark" from foldopen):
+  set foldopen=
+Then (g:markbar_foldopen should be false):
+  AssertEqual v:false, markbar#settings#foldopen()

--- a/test/standalone-test-foldopen.vader
+++ b/test/standalone-test-foldopen.vader
@@ -1,0 +1,38 @@
+Include: foldopen-helpers.vader
+" see foldopen-helpers.vader for comments and documentation
+
+Do (jumping to a closed, level 1 fold opens that fold):
+  'a
+Then:
+  let g:expected = {'4,5': 1, '9,10': 1, '7,10': 1, '2,10': 0, '3,5': 1}
+  call AssertClosedStateMatches(g:expected, GetClosedState())
+
+Do (jumping to a closed, level 2 fold in closed level 1 fold opens that fold):
+  'e
+Then:
+  let g:expected = {'4,5': 1, '9,10': 1, '7,10': 0, '2,10': 0, '3,5': 1}
+  call AssertClosedStateMatches(g:expected, GetClosedState())
+
+Do (jumping to a closed, level 2 fold above that fold in closed level 1 fold opens ONLY that fold):
+  'b
+Then:
+  let g:expected = {'4,5': 1, '9,10': 1, '7,10': 1, '2,10': 0, '3,5': 0}
+  call AssertClosedStateMatches(g:expected, GetClosedState())
+
+Do (jumping to a closed, level 3 fold in closed parent folds opens all three):
+  'c
+Then:
+  let g:expected = {'4,5': 0, '9,10': 1, '7,10': 1, '2,10': 0, '3,5': 0}
+  call AssertClosedStateMatches(g:expected, GetClosedState())
+
+Do (jumping to any fold won't open it if 'foldopen' doesn't contain false):
+  let g:markbar_foldopen = v:false\<cr>
+  'a
+  'b
+  'c
+  'd
+  'e
+  'f
+Then:
+  let g:expected = {'4,5': 1, '9,10': 1, '7,10': 1, '2,10': 1, '3,5': 1}
+  call AssertClosedStateMatches(g:expected, GetClosedState())


### PR DESCRIPTION
If `&foldopen` contains `mark`, then when jumping to a mark located within a closed fold, vim will open enough folds to make the mark visible. vim-markbar did not replicate this behavior when jumping from the standard and peekaboo markbars.

Add the `g:markbar_foldopen` setting, which autopopulates from `&foldopen` by default. Depending on its value, when jumping to a mark in a closed fold, open those folds with `zv`.

Closes #18.