### PR TITLE
Fix duplicate foldopen tags

### DIFF
--- a/doc/vim-markbar.txt
+++ b/doc/vim-markbar.txt
@@ -122,7 +122,7 @@ For options unique to the "peekaboo" markbar, see |vim-markbar-peekaboo-options|
     will default to `v:true`. Otherwise, this will default to `v:false`.
 
     Note that this variable is not synchronized to 'foldopen': it will not
-    update if 'foldopen' is changed after *g:markbar_foldopen* is initialized.
+    update if 'foldopen' is changed after |g:markbar_foldopen| is initialized.
 
 *g:markbar_open_vertical*                                |(v:t_bool)|
 *g:markbar_peekaboo_open_vertical*


### PR DESCRIPTION
I noticed:
```
  E154: Duplicate tag "g:markbar_foldopen" in file /nix/store/1xvh545n22z6x4amsa1824jiy0girh09-vimplugin-vim-markbar-2020-05-10/share/vim-plugins/vim-markbar/doc/vim-markbar.txtFailed to build help tags!
```
when reviewing https://github.com/NixOS/nixpkgs/pull/96044

This is to fix that issue.