### PR TITLE
Fix Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,17 @@
 ---
 language: vim
+dist: focal
 
 before_script:
   - sudo add-apt-repository ppa:jonathonf/vim -y
-  - |
-    if [[ `lsb_release -r | awk '{print $2}'` < 16.04 ]]; then
-      echo "Using neovim-ppa/unstable for Ubuntu version older than 16.04."
-      sudo add-apt-repository ppa:neovim-ppa/unstable -y
-    else
-      echo "Using neovim-ppa/stable for Ubuntu version 16.04 or newer."
-      sudo add-apt-repository ppa:neovim-ppa/stable   -y
-    fi
+  - sudo add-apt-repository ppa:neovim-ppa/stable -y
   - sudo apt-get update  -q
   - sudo apt-get install -y language-pack-de language-pack-es
   - |
-    sudo apt-get remove vim -y
     sudo apt-get install -y vim
     vim  --version
   - |
-    sudo apt-get install -y neovim vim
+    sudo apt-get install -y neovim
     nvim --version
   - git clone https://github.com/junegunn/vader.vim.git test/vader.vim
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.com/Yilin-Yang/vim-markbar.svg?branch=master)](https://travis-ci.com/Yilin-Yang/vim-markbar)
+[![Build Status](https://app.travis-ci.com/Yilin-Yang/vim-markbar.svg?branch=master)](https://app.travis-ci.com/Yilin-Yang/vim-markbar)
 
 vim-markbar
 ================================================================================

--- a/test/WindowHelpers.vader
+++ b/test/WindowHelpers.vader
@@ -10,10 +10,8 @@ Execute (Declare Window Helpers):
     let l:last_win = winnr('$')
     let l:win_state = [l:cur_win]
     let l:i = 1 | while l:i <=# l:last_win
-      execute l:i . 'wincmd w'
-      call add(l:win_state, [winwidth(0), winheight(0)])
+      call add(l:win_state, [winwidth(l:i), winheight(l:i)])
     let l:i += 1 | endwhile
-    execute l:cur_win . 'wincmd w'
     return l:win_state
   endfunction
 
@@ -33,8 +31,10 @@ Execute (Declare Window Helpers):
       let l:rwh = a:rhs[l:i]
 
       Assert AboutEqual(l:lwh[0], l:rwh[0], a:threshold),
-          \ printf('Widths are too different: %s, %s', l:lwh[0], l:rwh[0])
+          \ printf('Widths are too different for window %d: %s, %s',
+              \ l:i, l:lwh[0], l:rwh[0])
       Assert AboutEqual(l:lwh[1], l:rwh[1], a:threshold),
-          \ printf('Heights are too different: %s, %s', l:lwh[1], l:rwh[1])
+          \ printf('Heights are too different for window %d: %s, %s',
+              \ l:i, l:lwh[1], l:rwh[1])
     let l:i += 1 | endwhile
   endfunction

--- a/test/standalone-test-StandardMarkbarController.vader
+++ b/test/standalone-test-StandardMarkbarController.vader
@@ -198,7 +198,7 @@ Then:
 " Do (Rename Mark):
 "   :call g:standard_controller.openMarkbar()\<cr>
 "   7G
-"   rCovfefe the Strong\<cr>
+"   rNew Name\<cr>
 " Expect:
 "   " Press ? for help
 "   ['A]: 10lines.txt
@@ -206,7 +206,7 @@ Then:
 "       first line
 "       second line
 
-"   ['B]: Covfefe the Strong
+"   ['B]: New Name
 "       fourth line
 "       fifth line
 "       sixth line
@@ -220,7 +220,7 @@ Then:
 Execute (Explicitly Rename Mark):
   " NOTE: command line prompt used by 'rename' doesn't seem to work with vader
   let g:mark = g:model.getMarkData('B')
-  call g:mark.setName('Covfefe the Strong')
+  call g:mark.setName('New Name')
   call g:standard_controller.openMarkbar()
 Expect:
   " Press ? for help
@@ -229,7 +229,7 @@ Expect:
       first line
       second line
 
-  ['B]: Covfefe the Strong
+  ['B]: New Name
       fourth line
       fifth line
       sixth line
@@ -279,7 +279,7 @@ Expect:
   
 Do (Set New Marks):
   :edit! 10lines.txt\<cr>
-  1G5lmA5GmB10G$mC
+  1G05lmA5G0mB10G$mC
 
 Execute (Test Mark Highlighting, Backtick-like):
   let g:markbar_enable_mark_highlighting = v:true

--- a/test/standalone-test-openmarkbar.vader
+++ b/test/standalone-test-openmarkbar.vader
@@ -270,7 +270,7 @@ Then:
 Execute (Explicitly Rename Mark):
   " NOTE: command line prompt used by 'rename' doesn't seem to work with vader
   let g:mark = g:markbar_model.getMarkData('B')
-  call g:mark.setName('Covfefe the Strong')
+  call g:mark.setName('New Name')
   normal Mo
 Expect:
   " Press ? for help
@@ -279,7 +279,7 @@ Expect:
       first line
       second line
 
-  ['B]: Covfefe the Strong
+  ['B]: New Name
       fourth line
       fifth line
       sixth line

--- a/test/standalone-test-peekaboo.vader
+++ b/test/standalone-test-peekaboo.vader
@@ -38,7 +38,7 @@ Then:
 " this should fail
 Do (Set Marks, Peekaboo Markbar Open):
   :edit! 10lines.txt\<cr>
-  1G5lmA5GmB10GmC
+  1G05lmA5G0mB10G0mC
   '
 Then:
   AssertEqual 0, &buflisted

--- a/test/test-MarkbarView.vader
+++ b/test/test-MarkbarView.vader
@@ -27,7 +27,8 @@ Execute (Test Open Window):
   AssertEqual    1, getwinvar(g:winnr,    '&winfixwidth')
   AssertEqual    1, getwinvar(g:winnr,   '&winfixheight')
   AssertEqual    1, getwinvar(g:winnr,     '&cursorline')
-  AssertEqual    0, getwinvar(g:winnr,     '&foldcolumn')
+  " avoid type mismatch because &fdc is a string in neovim and a number in vim
+  Assert      0 ==# getwinvar(g:winnr,     '&foldcolumn')
   AssertEqual 'no', getwinvar(g:winnr,     '&signcolumn')
   AssertEqual    0, getwinvar(g:winnr, '&relativenumber')
   AssertEqual    0, getwinvar(g:winnr,         '&number')


### PR DESCRIPTION
Resuming maintenance of vim-markbar after ~two years absence!

Travis CI was failing because (1) the `apt` commands in `.travis.yml` stopped working for some reason and (2) the vim-markbar test suite was failing for newer builds of neovim. Fixing this thankfully didn't require any changes to the primary codebase.