### PR TITLE
Activate last-active window with win_gotoid()

### DIFF
--- a/test/standalone-test-openmarkbar.vader
+++ b/test/standalone-test-openmarkbar.vader
@@ -267,6 +267,28 @@ Then:
   " check column number
   AssertEqual 6, cur_pos[2]
 
+Do (Go To Mark Opens In Correct Window with markbar_open_position = 'topleft'):
+  :let g:markbar_open_position = 'topleft'\<cr>
+  :let g:last_window = win_getid()\<cr>
+  Mo
+  2G\<cr>
+Then:
+  let g:markbar_open_position = 'botright'
+
+  AssertEqual g:last_window, win_getid(), "Jumped to mark in wrong window!"
+
+Do (Go To Mark Opens In Correct Window With 'topleft' Horizontal Markbar):
+  :let g:markbar_open_position = 'topleft'\<cr>
+  :let g:markbar_open_vertical = v:false\<cr>
+  :let g:last_window = win_getid()\<cr>
+  Mo
+  2G\<cr>
+Then:
+  let g:markbar_open_position = 'botright'
+  let g:markbar_open_vertical = v:true
+
+  AssertEqual g:last_window, win_getid(), "Jumped to mark in wrong window!"
+
 Execute (Explicitly Rename Mark):
   " NOTE: command line prompt used by 'rename' doesn't seem to work with vader
   let g:mark = g:markbar_model.getMarkData('B')

--- a/test/standalone-test-peekaboo.vader
+++ b/test/standalone-test-peekaboo.vader
@@ -167,9 +167,32 @@ Then:
   " check column number
   AssertEqual 6, cur_pos[2]
 
+Do (Select and Go To to Mark, Opens in Correct Window with markbar_peekaboo_open_position = 'topleft'):
+  :let g:markbar_peekaboo_open_position = 'topleft'\<cr>
+  :let g:last_window = win_getid()\<cr>
+  `
+  \A\<cr>
+Then:
+  let g:markbar_peekaboo_open_position = 'botright'
+
+  AssertEqual g:last_window, win_getid(), "Jumped to mark in wrong window!"
+
+Do (Ditto (Select and Go To), with Horizontal Peekaboo Markbar):
+  :let g:markbar_peekaboo_open_position = 'topleft'\<cr>
+  :let g:markbar_peekaboo_open_vertical = v:false\<cr>
+  :let g:last_window = win_getid()\<cr>
+  `
+  \A\<cr>
+Then:
+  let g:markbar_peekaboo_open_position = 'botright'
+  let g:markbar_peekaboo_open_vertical = v:true
+
+  AssertEqual g:last_window, win_getid(), "Jumped to mark in wrong window!"
+
+
 Do (Go Direct To Mark, Apostrophe):
   '
-  A 
+  A
 Then:
   AssertEqual '10lines.txt', expand('%:t')
   let cur_pos = getcurpos()
@@ -193,6 +216,28 @@ Then:
 
   " check column number
   AssertEqual 6, cur_pos[2]
+
+Do (Go Direct to Mark, Opens in Correct Window with markbar_peekaboo_open_position = 'topleft'):
+  :let g:markbar_peekaboo_open_position = 'topleft'\<cr>
+  :let g:last_window = win_getid()\<cr>
+  `
+  A
+Then:
+  let g:markbar_peekaboo_open_position = 'botright'
+
+  AssertEqual g:last_window, win_getid(), "Jumped to mark in wrong window!"
+
+Do (Ditto (Go Direct), with Horizontal Peekaboo Markbar):
+  :let g:markbar_peekaboo_open_position = 'topleft'\<cr>
+  :let g:markbar_peekaboo_open_vertical = v:false\<cr>
+  :let g:last_window = win_getid()\<cr>
+  `
+  A
+Then:
+  let g:markbar_peekaboo_open_position = 'botright'
+  let g:markbar_peekaboo_open_vertical = v:true
+
+  AssertEqual g:last_window, win_getid(), "Jumped to mark in wrong window!"
 
 Do (View Single-Quote Mark):
   :let g:markbar_peekaboo_marks_to_display = '''ABC'\<cr>


### PR DESCRIPTION
Before jumping to a user's mark, the previous implementation would store the `winnr()` of the last-active window and return to that window with `wincmd w`. This fails when `g:markbar_open_position` is 'topleft' because the newly opened markbar would have `winnr()` 1, and the `winnr()` of all other windows would be incremented.

Instead store the `win_getid()` of the last-active window and return to it with `win_gotoid()`.

Closes #27.