### PR TITLE
Fix arrow keys causing peekaboo markbar to close

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,12 @@ let g:markbar_rename_mark_mapping   = '<F2>'
 let g:markbar_reset_mark_mapping    = 'r'
 let g:markbar_delete_mark_mapping   = '<Del>'
 
+" vim (not neovim) can behave weirdly when '<Esc>' is a mapping's LHS:
+" vim-markbar tries to work around this, but if e.g. the arrow keys cause
+" the peekaboo markbar to close erroneously, or if you prefer, you may want to
+" change this.
+let g:markbar_close_peekaboo_mapping = 'qq'
+
 " open/close markbar mappings
 nmap <Leader>m  <Plug>ToggleMarkbar
 nmap <Leader>mo <Plug>OpenMarkbar

--- a/autoload/markbar/settings.vim
+++ b/autoload/markbar/settings.vim
@@ -402,6 +402,19 @@ function! markbar#settings#PreviousMarkMapping() abort
     return g:markbar_previous_mark_mapping
 endfunction
 
+" RETURNS:  (v:t_string)    The keymapping used to close the peekaboo markbar.
+function! markbar#settings#ClosePeekabooMapping() abort
+    if !exists('g:markbar_close_peekaboo_mapping')
+        let g:markbar_close_peekaboo_mapping = '<Esc>'
+    endif
+    call s:AssertType(
+        \ g:markbar_close_peekaboo_mapping,
+        \ v:t_string,
+        \ 'g:markbar_close_peekaboo_mapping'
+    \ )
+    return g:markbar_close_peekaboo_mapping
+endfunction
+
 " RETURNS:  (v:t_bool)      `v:true` if the 'jump to mark from markbar'
 "                           mapping should go to the exact line *and column*
 "                           of the mark, or `v:false` if it should go to the

--- a/doc/vim-markbar.txt
+++ b/doc/vim-markbar.txt
@@ -276,6 +276,16 @@ For options unique to the "peekaboo" markbar, see |vim-markbar-peekaboo-options|
     The mapping used to move the cursor to the previous mark listed in the
     markbar.
 
+*g:markbar_close_peekaboo_mapping*                       |(v:t_string)|
+    `Default Value:` `<Esc>`
+
+    The mapping used to close the peekaboo markbar.
+
+    You may want to change this to `qq` or similar when using vim (not neovim)
+    in a terminal, because then the |^[| at the start of the |terminal-key-codes|
+    for keys like <S-Up> and <PageDown> might erroneously trigger this mapping.
+    vim-markbar tries to work around this.
+
 *g:markbar_jump_to_exact_position*                       |(v:t_bool)|
     `Default Value:` `v:true`
 

--- a/plugin/vim-markbar.vim
+++ b/plugin/vim-markbar.vim
@@ -257,16 +257,6 @@ if markbar#settings#EnablePeekabooMarkbar()
         let b:view  = g:markbar_view
         let b:model = g:markbar_model
 
-        noremap <silent> <buffer> <Esc> :call b:ctrl.closeMarkbar()<cr>
-        execute 'noremap <silent> <buffer> '
-            \ . markbar#settings#PeekabooJumpToMarkMapping()
-            \ . ' :call b:view.goToSelectedMark('
-                \ . (a:jump_like_backtick ? 'v:true' : 'v:false')
-            \ . ')<cr>'
-        execute 'noremap <silent> <buffer> ? '
-            \ . ':call b:fmt.flipOption("show_verbose_help")<cr>'
-            \ . ':call b:ctrl.refreshContents()<cr>'
-
         call g:markbar_peekaboo_select_keys.setCallback(
             \ { key, mods, prefix -> b:view.selectMark(key) }
         \ )
@@ -278,6 +268,32 @@ if markbar#settings#EnablePeekabooMarkbar()
                 \ 'noremap <silent> <buffer>')
         call g:markbar_peekaboo_jump_to_keys.setMappings(
                 \ 'noremap <silent> <buffer>')
+
+        execute printf('noremap <silent> <buffer> %s :call b:ctrl.closeMarkbar()<cr>',
+            \ markbar#settings#ClosePeekabooMapping())
+        execute 'noremap <silent> <buffer> '
+            \ . markbar#settings#PeekabooJumpToMarkMapping()
+            \ . ' :call b:view.goToSelectedMark('
+                \ . (a:jump_like_backtick ? 'v:true' : 'v:false')
+            \ . ')<cr>'
+        execute 'noremap <silent> <buffer> ? '
+            \ . ':call b:fmt.flipOption("show_verbose_help")<cr>'
+            \ . ':call b:ctrl.refreshContents()<cr>'
+
+        if !has('nvim')
+            " Work around |terminal-key-codes| like the arrow keys erroneously
+            " closing the peekaboo markbar when
+            " g:markbar_close_peekaboo_mapping ==? '<Esc>'.
+
+            " Apparently, setting any mapping with a literal <Esc> special
+            " character will cause <Up>, <Down>, etc. to start working
+            " correctly. |ttimeout| doesn't seem to affect anything.
+            "
+            " Tested with:
+            " VIM - Vi IMproved 8.2 (2019 Dec 12, compiled Apr 18 2022 19:26:30)
+            " Included patches: 1-3995
+            noremap <silent> <buffer> notarealkeycode <Nop>
+        endif
     endfunction
 
 endif

--- a/test/standalone-test-peekaboo.vader
+++ b/test/standalone-test-peekaboo.vader
@@ -93,10 +93,65 @@ Expect:
     tenth line
     ~
   
-Do (Close Peekaboo Markbar):
-  \<Esc>
+" vim in a terminal (but not neovim) interprets e.g. <Up> as ^[OA,
+" which might get parsed as <Esc> (close peekaboo markbar), O (insert line
+" above cursor), A (type the letter 'A'). This is undesirable behavior.
+"
+" See :h terminal-key-codes in vim.
+Execute (Arrow keys work for navigation inside peekaboo markbar):
+  normal '
+  normal! 9G05l
+  let g:old_cur_pos = getcurpos()
+  let g:up    = has('nvim') ? "\<Up>"    : &t_ku
+  let g:down  = has('nvim') ? "\<Down>"  : &t_kd
+  let g:left  = has('nvim') ? "\<Left>"  : &t_kl
+  let g:right = has('nvim') ? "\<Right>" : &t_kr
+
+  execute 'normal '.g:up
+  execute 'normal '.g:up
+  execute 'normal '.g:down
+  execute 'normal '.g:left
+  execute 'normal '.g:right
+  execute 'normal '.g:left
+
+  let g:cur_pos = getcurpos()
 Then:
-  Assert !exists('b:is_markbar')
+  AssertEqual 1, b:is_markbar
+  AssertEqual g:old_cur_pos[1] - 1, g:cur_pos[1]
+  AssertEqual g:old_cur_pos[2] - 1, g:cur_pos[2]
+
+Execute (PageUp and PageDown work for navigation inside peekaboo markbar):
+  normal '
+  normal! 9G05l
+  let g:old_cur_pos = getcurpos()
+  let g:pg_up    = has('nvim') ? "\<PageUp>"   : &t_kP
+  let g:pg_down  = has('nvim') ? "\<PageDown>" : &t_kN
+
+  execute 'normal '.g:pg_up
+  execute 'normal '.g:pg_down
+  execute 'normal '.g:pg_up
+  execute 'normal '.g:pg_down
+  execute 'normal '.g:pg_down
+
+  let g:cur_pos = getcurpos()
+Then:
+  AssertEqual 1, b:is_markbar
+  AssertNotEqual g:old_cur_pos[1], g:cur_pos[1]
+  AssertEqual len(getbufline(bufnr('%'), 1, '$')), g:cur_pos[1]
+
+Execute (Home and End work for navigation inside peekaboo markbar):
+  normal '
+  normal! 7G05l
+
+  let g:home = has('nvim') ? "\<Home>" : &t_kh
+  let g:end  = has('nvim') ? "\<End>"  : &t_@7
+
+  execute 'normal '.g:home
+  AssertEqual 1, b:is_markbar
+  AssertEqual 1, getcurpos()[2]
+
+  execute 'normal '.g:end
+  AssertEqual len("['B]: 10lines.txt [l: 5, c: 0]"), getcurpos()[2]
 
 Execute (Preserve Window Layout On Closing Peekaboo Markbar):
   vsplit
@@ -106,6 +161,31 @@ Execute (Preserve Window Layout On Closing Peekaboo Markbar):
   execute "normal \<Esc>"
 Then:
   call AssertWinStatesAboutEqual(g:saved_state, GetWinState(), 1)
+
+Execute (Close peekaboo markbar works with default <Esc> mapping):
+  " Do this after the '_ and _ work for navigation inside peekaboo markbar'
+  " tests because the default value for g:markbar_close_peekaboo_mapping
+  " is what causes |terminal-key-codes| to malfunction.
+  normal '
+  AssertEqual 1, b:is_markbar
+  execute "normal \<Esc>"
+  Assert !exists('b:is_markbar')
+
+Execute (Close peekaboo markbar works with different mapping):
+  let g:markbar_close_peekaboo_mapping = 'qq'
+  normal '
+  AssertEqual 1, b:is_markbar
+  execute "normal qq"
+  Assert !exists('b:is_markbar')
+
+Execute (Go-direct-to-mark doesn't clobber the close-markbar mapping):
+  let g:markbar_close_peekaboo_mapping = 'q'
+  normal '
+  AssertEqual 1, b:is_markbar
+  execute "normal q"
+  Assert !exists('b:is_markbar')
+Then:
+  let g:markbar_close_peekaboo_mapping = '<Esc>'
 
 Execute (Test Mark Highlighting, Backtick):
   let g:markbar_enable_mark_highlighting = v:true
@@ -255,6 +335,15 @@ Then:
 
   AssertEqual g:last_window, win_getid(), "Jumped to mark in wrong window!"
 
+Execute (Go-direct-to-mark doesn't clobber go-to-selected):
+  let g:markbar_peekaboo_jump_to_mark_mapping = 'A'
+  normal '
+  normal \BA
+Then:
+  let g:markbar_peekaboo_jump_to_mark_mapping = '<cr>'
+  let g:cur_pos = getcurpos()
+  AssertEqual 5, g:cur_pos[1]
+  AssertEqual 1, g:cur_pos[2]
 
 Execute (Go direct to mark with apostrophe works with jump_to_exact_position):
   let g:markbar_peekaboo_jump_to_exact_position = v:true


### PR DESCRIPTION
By default, `<Esc>` closes the peekaboo markbar. But when vim runs in a terminal, pressing `<Up>` might send `^[OA`, which vim might parse as "special character literal for `<Esc>`, capital `O`, capital `A`". Pressing `<Up>` in a peekaboo markbar would then close the peekaboo markbar, enter insert mode (new line above the cursor), and type a capital letter "A". Any terminal keycode starting with `^[` would cause this issue.

Fix this, and let the user change the "close peekaboo" mapping, in case the fix doesn't work for them.

Closes #28.