### PR TITLE
Add option to forcibly persist mark deletion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Session.vim
 *.swp
 *temp
 doc/tags
+viminfo_or_shada

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_script:
   - sudo add-apt-repository ppa:jonathonf/vim -y
   - sudo add-apt-repository ppa:neovim-ppa/stable -y
   - sudo apt-get update  -q
-  - sudo apt-get install -y language-pack-de language-pack-es
+  - sudo apt-get install -y language-pack-de
   - |
     sudo apt-get install -y vim
     vim  --version

--- a/README.md
+++ b/README.md
@@ -191,6 +191,17 @@ let g:markbar_delete_mark_mapping   = '<Del>'
 " change this.
 let g:markbar_close_peekaboo_mapping = 'qq'
 
+" Deleted marks may reappear in subsequent vim/neovim sessions. vim fixed
+" this in patch 8.2.0050; this is still an issue in neovim,
+" ref: https://github.com/neovim/neovim/issues/4295#issuecomment-544207151
+" and https://github.com/Yilin-Yang/vim-markbar/issues/20
+"
+" This option works around that issue by running |:wviminfo!| or |:wshada!|
+" whenever vim-markbar deletes a mark. Because that has side effects, this is
+" disabled by default, but if you don't care/don't know what viminfo/shada are,
+" then you can enable this to make mark deletion work as expected.
+let g:markbar_force_clear_shared_data_on_delmark = v:true
+
 " open/close markbar mappings
 nmap <Leader>m  <Plug>ToggleMarkbar
 nmap <Leader>mo <Plug>OpenMarkbar

--- a/autoload/markbar/BufferCache.vim
+++ b/autoload/markbar/BufferCache.vim
@@ -46,12 +46,8 @@ function! s:BufferCache.updateCache(marks_output, ...) abort dict
     let l:i = len(l:markstrings)
     while l:i
         let l:i -= 1
-        try
-            let l:markdata = markbar#MarkData#New(l:markstrings[l:i], l:bufname)
-            let l:new_marks_dict[l:markdata.getMarkChar()] = l:markdata
-        catch /markstring parsing failed/
-            " drop this markdata
-        endtry
+        let l:markdata = markbar#MarkData#New(l:markstrings[l:i], l:bufname)
+        let l:new_marks_dict[l:markdata.getMarkChar()] = l:markdata
     endwhile
 
     " copy over existing mark names

--- a/autoload/markbar/helpers.vim
+++ b/autoload/markbar/helpers.vim
@@ -52,9 +52,7 @@ function! markbar#helpers#GetLocalMarks() abort
     let l:to_return = ''
     try
         redir => l:to_return
-        " this prints *all* marks except (, ), {, }
-        " not sure if that's desired behavior, so this may be brittle
-        silent marks "
+        silent marks
         redir end
         let l:to_return .= "\n"
     catch /E283/

--- a/autoload/markbar/settings.vim
+++ b/autoload/markbar/settings.vim
@@ -46,6 +46,19 @@ function! markbar#settings#foldopen() abort
     return g:markbar_foldopen
 endfunction
 
+" RETURNS:  (v:t_bool)      Whether to :wviminfo!/:wshada! on deleting a mark.
+function! markbar#settings#ForceClearSharedDataOnDelmark() abort
+    if !exists('g:markbar_force_clear_shared_data_on_delmark')
+        let g:markbar_force_clear_shared_data_on_delmark = v:false
+    endif
+    call s:AssertType(
+        \ g:markbar_force_clear_shared_data_on_delmark,
+        \ v:t_bool,
+        \ 'g:markbar_force_clear_shared_data_on_delmark'
+    \ )
+    return g:markbar_force_clear_shared_data_on_delmark
+endfunction
+
 " RETURNS:  (v:t_bool)      Whether to open markbars as vertical splits
 "                           (`v:true`) or horizontal splits (`v:false`).
 function! markbar#settings#MarkbarOpenVertical() abort

--- a/doc/vim-markbar.txt
+++ b/doc/vim-markbar.txt
@@ -124,6 +124,22 @@ For options unique to the "peekaboo" markbar, see |vim-markbar-peekaboo-options|
     Note that this variable is not synchronized to 'foldopen': it will not
     update if 'foldopen' is changed after |g:markbar_foldopen| is initialized.
 
+*g:markbar_force_clear_shared_data_on_delmark*           |(v:t_bool)|
+    `Default Value`: `v:false`
+
+    Whether to `:wviminfo!` or `:wshada!` on deleting a mark.
+
+    vim versions without patch 8.2.0050 and all neovim versions (as of the
+    time of writing) may not "remember" when marks are deleted, i.e. a mark
+    deleted through the markbar may reappear in the markbar after closing and
+    reopening (neo)vim.
+
+    A heavy-handed solution to this is to |:wviminfo!| in vim or |:wshada!| in
+    neovim whenever vim-markbar deletes a mark. This has the side effect of
+    "throwing away" the old contents of the |viminfo-file| or |shada-file|,
+    and possibly resetting |'quote| marks. Because of those side effects, this
+    option is disabled by default.
+
 *g:markbar_open_vertical*                                |(v:t_bool)|
 *g:markbar_peekaboo_open_vertical*
     `Default Value:` `v:true`

--- a/test/standalone-test-openmarkbar.vader
+++ b/test/standalone-test-openmarkbar.vader
@@ -724,3 +724,38 @@ Expect:
       ~
       ~
   
+Execute (Configure to display only ' and " marks):
+  let g:markbar_num_lines_context = 0
+  let g:markbar_section_separation = 0
+  let g:markbar_marks_to_display = '''"'
+  let g:markbar_mark_name_format_string = 'mark'
+  let g:markbar_mark_name_arguments = []
+  edit! 10lines.txt
+  normal! m'm"
+  normal Mo
+Expect:
+  " Press ? for help
+  ['']: mark
+  ['"]: mark
+
+Do (Trying to delete the ' mark prints an error message):
+  :edit! 10lines.txt\<cr>
+  Mogg
+  nd
+Then:
+  AssertEqual "\nCannot delete the ' mark.", LastMessage()
+Expect:
+  " Press ? for help
+  ['']: mark
+  ['"]: mark
+
+Do (Trying to delete the " mark prints an error message):
+  :edit! 10lines.txt\<cr>
+  Moggnn
+  d
+Then:
+  AssertEqual "\nCannot delete the \" mark.", LastMessage()
+Expect:
+  " Press ? for help
+  ['']: mark
+  ['"]: mark

--- a/test/standalone-test-sequential-delmarks.vader/01-standalone-test-sequential-delmarks.vader
+++ b/test/standalone-test-sequential-delmarks.vader/01-standalone-test-sequential-delmarks.vader
@@ -1,0 +1,14 @@
+Include: set-settings.vader
+
+Do (Set Marks, Open Markbar):
+  :edit! 10lines.txt\<cr>
+  1G05lmA5G05lmB10G05lmC
+  2G0ma4G$mb
+  Mo
+Expect:
+  " Press ? for help
+  ['a]: (l: 2, c: 0)
+  ['b]: (l: 4, c: 10)
+  ['A]: 10lines.txt [l: 1, c: 5]
+  ['B]: 10lines.txt [l: 5, c: 5]
+  ['C]: 10lines.txt [l: 10, c: 5]

--- a/test/standalone-test-sequential-delmarks.vader/02-standalone-test-sequential-delmarks.vader
+++ b/test/standalone-test-sequential-delmarks.vader/02-standalone-test-sequential-delmarks.vader
@@ -1,0 +1,8 @@
+Include: set-settings.vader
+
+Do (Delete All Marks):
+  :edit! 10lines.txt\<cr>
+  Mo
+  GdGdGdGdGd
+Expect:
+  " Press ? for help

--- a/test/standalone-test-sequential-delmarks.vader/03-standalone-test-sequential-delmarks.vader
+++ b/test/standalone-test-sequential-delmarks.vader/03-standalone-test-sequential-delmarks.vader
@@ -1,0 +1,7 @@
+Include: set-settings.vader
+
+Do (Open Markbar):
+  :edit! 10lines.txt\<cr>
+  Mo
+Expect (Marks that were deleted stay deleted):
+  " Press ? for help

--- a/test/standalone-test-sequential-delmarks.vader/set-settings.vader
+++ b/test/standalone-test-sequential-delmarks.vader/set-settings.vader
@@ -1,0 +1,12 @@
+Execute (Set Settings):
+  let g:markbar_enable_mark_highlighting = v:false
+  let g:markbar_num_lines_context = 0
+  let g:markbar_section_separation = 0
+
+  let g:markbar_marks_to_display='abcABC'
+
+  let g:markbar_force_clear_shared_data_on_delmark = v:true
+
+  map Mo <Plug>OpenMarkbar
+  map Mc <Plug>CloseMarkbar
+  map Mt <Plug>ToggleMarkbar


### PR DESCRIPTION
Add option to `:wviminfo!` or `:wshada!` on mark deletion, which works
around neovim's ShaDa implementation not recognizing when a mark was
deleted in a previous editing session.

Modify run_tests.sh script:
- Fix helptext for `-f`/`--file=` and `-e`/`--vim_exe=` options.
- Make it possible to run "sequential" standalone tests, where vim uses
  the same viminfo/shada file, but is closed and reopened between each
  test.
- Don't duplicate 'vim' or 'nvim' in `BASE_CMD_*` when running visibly.
- Terminate the test script on unrecognized arguments.
- Style fixes.

Also:
- Only test against a German locale, not a Spanish one. German acts as a
  regression test for #5, and running in Spanish doesn't offer
  additional meaningful test coverage.
- Don't fail silently when markstring parsing fails. That shouldn't
  ever happen, but if it does, I want users to report it.
- Print useful error messages when a user tries to delete the `'` or `"`
  marks. `"` can technically be deleted, but it gets reset by `:wshada`, and
  writing logic to work around that edge case (plus tests) is more
  trouble than it's worth.

Closes #20.