### PR TITLE
Tweak "persist mark names" docs and error message; fix tests; stop using numbered-functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ By default, you:
 - **Delete marks entirely** using `d`.
 
 **Note** that deleted marks may reappear in subsequent editor sessions in
-[neovim](https://github.com/vim/vim/issues/1339) and [vim < 8.2.0050](https://github.com/vim/vim/issues/1339).
+[neovim](https://github.com/neovim/neovim/issues/4295) and [vim < 8.2.0050](https://github.com/vim/vim/issues/1339).
 Set `g:markbar_force_clear_shared_data_on_delmark = v:true` as a heavy-handed
 workaround.
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ git clone https://github.com/Yilin-Yang/vim-markbar.git
 
 Quick Start
 --------------------------------------------------------------------------------
-At a minimum, you should set some of the following keymappings in your `.vimrc`.
+At a minimum, you should set the following in your `.vimrc`.
 
 ```vim
 nmap <Leader>m <Plug>ToggleMarkbar
@@ -80,6 +80,13 @@ nmap <Leader>m <Plug>ToggleMarkbar
 " the following are unneeded if ToggleMarkbar is mapped
 nmap <Leader>mo <Plug>OpenMarkbar
 nmap <Leader>mc <Plug>CloseMarkbar
+
+" this is required for mark names to persist between editor sessions
+if has('nvim')
+    set shada+=!
+else
+    set viminfo+=!
+endif
 ```
 
 These examples use the [leader key,](https://stackoverflow.com/questions/1764263/what-is-the-leader-in-a-vimrc-file)
@@ -127,7 +134,7 @@ let g:markbar_reset_mark_mapping = '<BS>'
 The "peekaboo" markbar is meant to be used in the same fashion as vim's
 built-in "jump to mark" functionality: to jump to a mark, the user
 only needs to press `'` or `` ` ``, and then the key corresponding to their
-target mark, e.g. `'a` to jump to mark `a`.
+target mark. Pressing `'a` will open the peekaboo markbar and jump to mark `a`.
 
 By default, pressing the apostrophe key (`'`) or the backtick key (`` ` ``)
 opens the peekaboo markbar with apostrophe-like or backtick-like behavior,
@@ -195,6 +202,13 @@ let g:markbar_delete_mark_mapping   = '<Del>'
 " change this.
 let g:markbar_close_peekaboo_mapping = 'qq'
 
+" when true, the peekaboo markbar only opens if the user waits for timeoutlen
+" milliseconds after hitting ' or `
+let g:markbar_explicitly_remap_mark_mappings = v:true
+
+" to disable the peekaboo markbar entirely
+" let g:markbar_enable_peekaboo = v:false
+
 " Deleted marks may reappear in subsequent vim/neovim sessions. vim fixed
 " this in patch 8.2.0050; this is still an issue in neovim,
 " ref: https://github.com/neovim/neovim/issues/4295#issuecomment-544207151
@@ -212,8 +226,7 @@ let g:markbar_force_clear_shared_data_on_delmark = v:true
 
 " Persistent mark names requires viminfo-!/shada-!
 if has('nvim')
-    " neovim includes ! in &shada by default
-    " set shada+=!
+    set shada+=!
 else
     set viminfo+=!
 endif

--- a/autoload/markbar/BufferCache.vim
+++ b/autoload/markbar/BufferCache.vim
@@ -22,7 +22,7 @@ function! markbar#BufferCache#New(buffer_no, rosters) abort
 endfunction
 
 " RETURNS:  (markbar#MarkData)  MarkData of the requested mark.
-function! s:BufferCache.getMark(mark) abort dict
+function! markbar#BufferCache#getMark(mark) abort dict
     let l:is_quote = a:mark ==# "'" || a:mark ==# '`'
     let l:mark = (l:is_quote) ? "'" : a:mark
     try
@@ -32,6 +32,7 @@ function! s:BufferCache.getMark(mark) abort dict
     endtry
     return l:md
 endfunction
+let s:BufferCache.getMark = function('markbar#BufferCache#getMark')
 
 " EFFECTS:  Repopulate BufferCache's `marks_dict` with the given marks output.
 " PARAM:    marks_output    (v:t_string)    Raw output of |:marks|.
@@ -41,7 +42,7 @@ endfunction
 " PARAM:    filepath        (v:t_string)    Full filepath for the buffer being
 "                                           queried by |:marks|. Ignored for
 "                                           global marks.
-function! s:BufferCache.updateCache(marks_output, bufname, filepath) abort dict
+function! markbar#BufferCache#updateCache(marks_output, bufname, filepath) abort dict
     call markbar#ensure#IsString(a:marks_output)
     call markbar#ensure#IsString(a:bufname)
     call markbar#ensure#IsString(a:filepath)
@@ -88,12 +89,13 @@ function! s:BufferCache.updateCache(marks_output, bufname, filepath) abort dict
 
     let l:self.marks_dict = l:new_marks_dict
 endfunction
+let s:BufferCache.updateCache = function('markbar#BufferCache#updateCache')
 
 " EFFECTS:  - Retrieve new contexts for this BufferCache's marks.
 "           - Clear cached mark contexts for marks that shouldn't exist anymore.
 "           - Fetch updated contexts for all marks.
 " PARAM:    num_lines   (v:t_number)    Number of lines of context to retrieve.
-function! s:BufferCache.updateContexts(num_lines) abort dict
+function! markbar#BufferCache#updateContexts(num_lines) abort dict
     let l:using_global_marks = l:self.isGlobal()
     let l:buffer_no = l:self._buffer_no
     for l:mark in keys(l:self.marks_dict)
@@ -113,7 +115,9 @@ function! s:BufferCache.updateContexts(num_lines) abort dict
         call l:mark_data.setContext(l:context)
     endfor
 endfunction
+let s:BufferCache.updateContexts = function('markbar#BufferCache#updateContexts')
 
-function! s:BufferCache.isGlobal() abort dict
+function! markbar#BufferCache#isGlobal() abort dict
     return l:self._buffer_no ==# 0
 endfunction
+let s:BufferCache.isGlobal = function('markbar#BufferCache#isGlobal')

--- a/autoload/markbar/ConditionalStack.vim
+++ b/autoload/markbar/ConditionalStack.vim
@@ -33,7 +33,7 @@ endfunction
 " EFFECTS:  Push a new element onto the given ConditionalStack.
 " RETURNS:  (v:t_bool)  `v:true` if the push succeeded (i.e. if the new
 "                       element was valid, and was added to the stack.)
-function! s:ConditionalStack.push(element) abort dict
+function! markbar#ConditionalStack#push(element) abort dict
     if !l:self.IsValid(a:element)
         return v:false
     endif
@@ -44,10 +44,11 @@ function! s:ConditionalStack.push(element) abort dict
     endif
     return v:true
 endfunction
+let s:ConditionalStack.push = function('markbar#ConditionalStack#push')
 
 " EFFECTS:  - Return the topmost valid element in the ConditionalStack.
 "           - Throw an exception if none could be found.
-function! s:ConditionalStack.top() abort dict
+function! markbar#ConditionalStack#top() abort dict
     let l:stack = l:self._data
     let l:IsValid = l:self.IsValid
     while len(l:stack) && !l:IsValid(l:stack[-1])
@@ -58,15 +59,17 @@ function! s:ConditionalStack.top() abort dict
     endif
     return l:stack[-1]
 endfunction
+let s:ConditionalStack.top = function('markbar#ConditionalStack#top')
 
 " EFFECTS:  Return the total number of elements, valid and invalid, currently
 "           in the ConditionalStack.
-function! s:ConditionalStack.size() abort dict
+function! markbar#ConditionalStack#size() abort dict
     return len(l:self._data)
 endfunction
+let s:ConditionalStack.size = function('markbar#ConditionalStack#size')
 
 " EFFECTS:  Remove all invalid elements from the stack.
-function! s:ConditionalStack.clean() abort dict
+function! markbar#ConditionalStack#clean() abort dict
     let l:stack = l:self._data
     let l:IsValid = l:self.IsValid
     let l:i = len(l:stack)
@@ -78,13 +81,15 @@ function! s:ConditionalStack.clean() abort dict
         call remove(l:stack, l:i)
     endwhile
 endfunction
+let s:ConditionalStack.clean = function('markbar#ConditionalStack#clean')
 
 " EFFECTS:  Discard the first half of the ConditionalStack if it exceeds its
 "           maximum size threshold.
-function! s:ConditionalStack.shrink() abort dict
+function! markbar#ConditionalStack#shrink() abort dict
     let l:stack = l:self._data
     let l:size = len(l:stack)
     if l:size > l:self._max_size
         let l:self._data = l:stack[l:size/2:]
     endif
 endfunction
+let s:ConditionalStack.shrink = function('markbar#ConditionalStack#shrink')

--- a/autoload/markbar/KeyMapper.vim
+++ b/autoload/markbar/KeyMapper.vim
@@ -146,10 +146,11 @@ function! markbar#KeyMapper#ParseModifiers(mods_as_str) abort
 endfunction
 
 " BRIEF:    Replace the callback function used as the RHS in mappings.
-function! s:KeyMapper.setCallback(NewCallback) abort dict
+function! markbar#KeyMapper#setCallback(NewCallback) abort dict
     call markbar#ensure#IsFuncref(a:NewCallback)
     let l:self._Callback = a:NewCallback
 endfunction
+let s:KeyMapper.setCallback = function('markbar#KeyMapper#setCallback')
 
 " BRIEF:    Set all keymappings.
 " PARAM:    mapcommand  (v:t_string)    The particular ':map' command to use
@@ -159,7 +160,7 @@ endfunction
 "                               <expr>`).
 " DETAILS:  See `:help :map-commands` and `:help :map-arguments` for details
 "           on how to format a:mapcommand.
-function! s:KeyMapper.setMappings(mapcommand) abort dict
+function! markbar#KeyMapper#setMappings(mapcommand) abort dict
     let l:keys_to_map_ref = l:self._keys_to_map
     for [l:map_cmd_lhs, l:lhs_pieces] in l:keys_to_map_ref
         let l:prefix = l:lhs_pieces[2]
@@ -199,3 +200,4 @@ function! s:KeyMapper.setMappings(mapcommand) abort dict
         execute l:command
     endfor
 endfunction
+let s:KeyMapper.setMappings = function('markbar#KeyMapper#setMappings')

--- a/autoload/markbar/MarkData.vim
+++ b/autoload/markbar/MarkData.vim
@@ -54,7 +54,7 @@ function! markbar#MarkData#New(markstring, bufname, filepath) abort
 endfunction
 
 " RETURNS:  (v:t_string)    Default name for a mark, or an empty string.
-function! s:MarkData.getDefaultName() abort
+function! markbar#MarkData#getDefaultName() abort dict
     let l:mark = l:self.getMarkChar()
     if l:mark ==# "'"
         return 'Last Jump'
@@ -83,59 +83,69 @@ function! s:MarkData.getDefaultName() abort
     endif
     return ''
 endfunction
+let s:MarkData.getDefaultName = function('markbar#MarkData#getDefaultName')
 
-function! s:MarkData.getMarkChar() abort dict
+function! markbar#MarkData#getMarkChar() abort dict
     return l:self._mark_char
 endfunction
+let s:MarkData.getMarkChar = function('markbar#MarkData#getMarkChar')
 
-function! s:MarkData.getLineNo() abort dict
+function! markbar#MarkData#getLineNo() abort dict
     return l:self._line_no
 endfunction
+let s:MarkData.getLineNo = function('markbar#MarkData#getLineNo')
 
-function! s:MarkData.getColumnNo() abort dict
+function! markbar#MarkData#getColumnNo() abort dict
     return l:self._column_no
 endfunction
+let s:MarkData.getColumnNo = function('markbar#MarkData#getColumnNo')
 
 " RETURNS:  (v:t_string)    User-provided name for this mark, or ''.
-function! s:MarkData.getUserName() abort dict
+function! markbar#MarkData#getUserName() abort dict
     return l:self._name
 endfunction
+let s:MarkData.getUserName = function('markbar#MarkData#getUserName')
 
-function! s:MarkData.getContext() abort dict
+function! markbar#MarkData#getContext() abort dict
     return l:self._context
 endfunction
+let s:MarkData.getContext = function('markbar#MarkData#getContext')
 
-function! s:MarkData.isGlobal() abort dict
+function! markbar#MarkData#isGlobal() abort dict
     return markbar#helpers#IsGlobalMark(l:self.getMarkChar())
 endfunction
+let s:MarkData.isGlobal = function('markbar#MarkData#isGlobal')
 
 " EFFECTS:  Set user-given name for this mark.
-function! s:MarkData.setUserName(new_name) abort dict
+function! markbar#MarkData#setUserName(new_name) abort dict
     let l:self._name = a:new_name
 endfunction
+let s:MarkData.setUserName = function('markbar#MarkData#setUserName')
 
 " EFFECTS:  Update the context for a particular mark.
 " PARAM:    new_context (v:t_list)  List of strings, where each string is a
 "                                   line of context from around the mark.
-function! s:MarkData.setContext(new_context) abort dict
+function! markbar#MarkData#setContext(new_context) abort dict
     let l:self._context = a:new_context
 endfunction
+let s:MarkData.setContext = function('markbar#MarkData#setContext')
 
 " RETURNS:  (v:t_string)    |bufname()| of the buffer that contains this mark.
 "                           When MarkData represents a global mark, this comes
 "                           from a |bufname()| lookup.
-function! s:MarkData.getBufname() abort dict
+function! markbar#MarkData#getBufname() abort dict
     if l:self.isGlobal()
         return bufname(markbar#helpers#BufferNo(l:self.getMarkChar()))
     else
         return l:self._bufname
     endif
 endfunction
+let s:MarkData.getBufname = function('markbar#MarkData#getBufname')
 
 " RETURNS:  (v:t_string)    Full path to the file holding this mark.
 "                           When MarkData represents a global mark, this comes
 "                           from a lookup.
-function! s:MarkData.getFilename() abort dict
+function! markbar#MarkData#getFilename() abort dict
     if l:self.isGlobal()
         let l:bufnr = markbar#helpers#BufferNo(l:self.getMarkChar())
         return expand(printf('#%s:p', l:bufnr))
@@ -143,3 +153,4 @@ function! s:MarkData.getFilename() abort dict
         return l:self._filepath
     endif
 endfunction
+let s:MarkData.getFilename = function('markbar#MarkData#getFilename')

--- a/autoload/markbar/MarkbarController.vim
+++ b/autoload/markbar/MarkbarController.vim
@@ -29,7 +29,7 @@ endfunction
 "           - Open this markbar buffer in a sidebar if the markbar is not yet
 "           open, or refresh its contents if it is already open.
 "           - Set autocmds to refresh the markbar buffer if it remains open.
-function! s:MarkbarController.openMarkbar() abort dict
+function! markbar#MarkbarController#openMarkbar() abort dict
     call l:self._markbar_model.updateCurrentAndGlobal()
 
     let l:open_vertical = markbar#settings#MarkbarOpenVertical()
@@ -42,18 +42,21 @@ function! s:MarkbarController.openMarkbar() abort dict
     " doesn't need to be open in order for the contents to refresh
     call l:self.refreshContents()
 endfunction
+let s:MarkbarController.openMarkbar = function('markbar#MarkbarController#openMarkbar')
 
-function! s:MarkbarController.closeMarkbar() abort dict
+function! markbar#MarkbarController#closeMarkbar() abort dict
     return l:self._markbar_view.closeMarkbar()
 endfunction
+let s:MarkbarController.closeMarkbar = function('markbar#MarkbarController#closeMarkbar')
 
-function! s:MarkbarController.toggleMarkbar() abort dict
+function! markbar#MarkbarController#toggleMarkbar() abort dict
     if l:self._markbar_view.closeMarkbar() | return | endif
     call l:self.openMarkbar()
 endfunction
+let s:MarkbarController.toggleMarkbar = function('markbar#MarkbarController#toggleMarkbar')
 
 " BRIEF:    Update cached marks; clear and repopulate the markbar buffer.
-function! s:MarkbarController.refreshContents() abort dict
+function! markbar#MarkbarController#refreshContents() abort dict
     let l:model = l:self._markbar_model
     let l:view  = l:self._markbar_view
 
@@ -82,9 +85,10 @@ function! s:MarkbarController.refreshContents() abort dict
         call l:self._populateWithMarkbar(l:active_buffer)
     endtry
 endfunction
+let s:MarkbarController.refreshContents = function('markbar#MarkbarController#refreshContents')
 
 " BRIEF:    Replace the target buffer with the marks/contexts of the given buffer.
-function! s:MarkbarController._populateWithMarkbar(for_buffer_no) abort dict
+function! markbar#MarkbarController#_populateWithMarkbar(for_buffer_no) abort dict
     let l:local_cache = l:self._markbar_model.getBufferCache(a:for_buffer_no)
     let l:global_cache = l:self._markbar_model.getBufferCache(0)
     let l:contents = l:self._text_generator.getText(
@@ -93,3 +97,4 @@ function! s:MarkbarController._populateWithMarkbar(for_buffer_no) abort dict
     let l:markbar_buffer = l:self._markbar_view.getMarkbarBuffer()
     call markbar#helpers#ReplaceBuffer(l:markbar_buffer, l:contents)
 endfunction
+let s:MarkbarController._populateWithMarkbar = function('markbar#MarkbarController#_populateWithMarkbar')

--- a/autoload/markbar/MarkbarFormat.vim
+++ b/autoload/markbar/MarkbarFormat.vim
@@ -53,7 +53,7 @@ function! markbar#MarkbarFormat#New(options) abort
 endfunction
 
 " BRIEF:    Throw an exception if a value has the wrong type for an option.
-function! s:MarkbarFormat.ensureCorrectTypeForOption(option, value) abort dict
+function! markbar#MarkbarFormat#ensureCorrectTypeForOption(option, value) abort dict
     call markbar#ensure#IsString(a:option)
     let l:correct_type = get(s:options_and_types, a:option, v:null)
     if l:correct_type is v:null
@@ -66,28 +66,31 @@ function! s:MarkbarFormat.ensureCorrectTypeForOption(option, value) abort dict
             \ markbar#helpers#VimLTypeToString(l:correct_type))
     endif
 endfunction
+let s:MarkbarFormat.ensureCorrectTypeForOption = function('markbar#MarkbarFormat#ensureCorrectTypeForOption')
 
 " EFFECTS:  Change an option's value. Throw exception on bad option name or if
 "           type doesn't match.
-function! s:MarkbarFormat.setOption(option, new_value) abort dict
+function! markbar#MarkbarFormat#setOption(option, new_value) abort dict
     call markbar#ensure#IsString(a:option)
     call l:self.ensureCorrectTypeForOption(a:option, a:new_value)
     let l:self._options[a:option] = a:new_value
 endfunction
+let s:MarkbarFormat.setOption = function('markbar#MarkbarFormat#setOption')
 
 " EFFECTS:  Change multiple options' values. Throw exception on a bad option
 "           name or if a given type doesn't match.
-function! s:MarkbarFormat.setOptions(options) abort dict
+function! markbar#MarkbarFormat#setOptions(options) abort dict
     call markbar#ensure#IsDictionary(a:options)
     for [l:option, l:new_value] in items(a:options)
         call l:self.setOption(l:option, l:new_value)
     endfor
 endfunction
+let s:MarkbarFormat.setOptions = function('markbar#MarkbarFormat#setOptions')
 
 " EFFECTS:  Flip a boolean option's value.
 "           Exists because `type(!v:true) == v:t_number`, so flipping a
 "           boolean option through setOption is needlessly convoluted.
-function! s:MarkbarFormat.flipOption(option) abort dict
+function! markbar#MarkbarFormat#flipOption(option) abort dict
     call markbar#ensure#IsString(a:option)
     let l:cur_val = l:self.getOption(a:option)
     if type(l:cur_val) !=# v:t_bool
@@ -95,9 +98,10 @@ function! s:MarkbarFormat.flipOption(option) abort dict
     endif
     call l:self.setOption(a:option, l:cur_val ? v:false : v:true)
 endfunction
+let s:MarkbarFormat.flipOption = function('markbar#MarkbarFormat#flipOption')
 
 " EFFECTS:  Get an option's value. Throw exception if option doesn't exist.
-function! s:MarkbarFormat.getOption(option) abort dict
+function! markbar#MarkbarFormat#getOption(option) abort dict
     call markbar#ensure#IsString(a:option)
     let l:value = get(l:self._options, a:option, v:null)
     if l:value is v:null
@@ -105,3 +109,4 @@ function! s:MarkbarFormat.getOption(option) abort dict
     endif
     return l:value
 endfunction
+let s:MarkbarFormat.getOption = function('markbar#MarkbarFormat#getOption')

--- a/autoload/markbar/MarkbarModel.vim
+++ b/autoload/markbar/MarkbarModel.vim
@@ -72,7 +72,7 @@ endfunction
 " PARAM:    new_name?   (v:t_string)    New name for the mark. If not present
 "                                       or empty, prompt the user to enter a
 "                                       new name.
-function! s:MarkbarModel.renameMark(mark, ...) abort dict
+function! markbar#MarkbarModel#renameMark(mark, ...) abort dict
     if s:WarnIfValidMarkCharIsEmpty(a:mark, 'renaming')
         return
     endif
@@ -89,23 +89,25 @@ function! s:MarkbarModel.renameMark(mark, ...) abort dict
 
     call s:UpdateNameAndRosterEntry(l:self._rosters, l:mark_data, l:new_name)
 endfunction
+let s:MarkbarModel.renameMark = function('markbar#MarkbarModel#renameMark')
 
 " BRIEF:    Reset the the selected mark's name to the default.
 " DETAILS:  Changes won't appear until the markbar has been repopulated.
 " PARAM:    mark    (v:t_string)    Single character representing the mark.
-function! s:MarkbarModel.resetMark(mark) abort dict
+function! markbar#MarkbarModel#resetMark(mark) abort dict
     if s:WarnIfValidMarkCharIsEmpty(a:mark, 'name-clearing')
         return
     endif
     let l:mark_data = l:self.getMarkData(a:mark)
     call s:UpdateNameAndRosterEntry(l:self._rosters, l:mark_data, '')
 endfunction
+let s:MarkbarModel.resetMark = function('markbar#MarkbarModel#resetMark')
 
 " BRIEF:    Delete the given mark, and remove it from the cache.
 " DETAILS:  Changes won't appear until the markbar has been repopulated.
 "           Must be invoked while the cursor is inside a markbar.
 " PARAM:    mark    (v:t_string)    The single character representing the mark.
-function! s:MarkbarModel.deleteMark(mark) abort dict
+function! markbar#MarkbarModel#deleteMark(mark) abort dict
     if s:WarnIfValidMarkCharIsEmpty(a:mark, 'deletion')
         return
     endif
@@ -148,15 +150,17 @@ function! s:MarkbarModel.deleteMark(mark) abort dict
         endif
     endif
 endfunction
+let s:MarkbarModel.deleteMark = function('markbar#MarkbarModel#deleteMark')
 
 " RETURNS:  (v:t_number)    The most recently accessed 'real' buffer.
-function! s:MarkbarModel.getActiveBuffer() abort dict
+function! markbar#MarkbarModel#getActiveBuffer() abort dict
     return l:self._active_buffer_stack.top()
 endfunction
+let s:MarkbarModel.getActiveBuffer = function('markbar#MarkbarModel#getActiveBuffer')
 
 " EFFECTS:  Push the given buffer number onto the active buffer
 "           ConditionalStack.
-function! s:MarkbarModel.pushNewBuffer(buffer_no) abort dict
+function! markbar#MarkbarModel#pushNewBuffer(buffer_no) abort dict
     if type(a:buffer_no) ==# v:t_list
         for l:no in a:buffer_no
             call l:self.pushNewBuffer(l:no)
@@ -166,6 +170,7 @@ function! s:MarkbarModel.pushNewBuffer(buffer_no) abort dict
     call markbar#ensure#IsNumber(a:buffer_no)
     call l:self._active_buffer_stack.push(a:buffer_no)
 endfunction
+let s:MarkbarModel.pushNewBuffer = function('markbar#MarkbarModel#pushNewBuffer')
 
 " RETURNS:  (markbar#MarkData)  The MarkData object corresponding to the given
 "                               mark character.
@@ -175,7 +180,7 @@ endfunction
 "           - If the requested mark is a global (file or numbered) mark, then
 "           the MarkbarModel object will search the global BufferCache.
 "           - If the requested mark cannot be found, throw an exception.
-function! s:MarkbarModel.getMarkData(mark_char) abort dict
+function! markbar#MarkbarModel#getMarkData(mark_char) abort dict
     let l:is_global = markbar#helpers#IsGlobalMark(a:mark_char)
     let l:mark_buffer =
             \ l:is_global ? 0 : l:self.getActiveBuffer()
@@ -188,11 +193,12 @@ function! s:MarkbarModel.getMarkData(mark_char) abort dict
     let l:mark = l:marks_dict[a:mark_char]
     return l:mark
 endfunction
+let s:MarkbarModel.getMarkData = function('markbar#MarkbarModel#getMarkData')
 
 " RETURNS:  (markbar#BufferCache)   BufferCache for the requested buffer.
 " DETAILS:  Initializes a BufferCache for the buffer if one doesn't exist.
 " PARAM:    buffer_no   (v:t_number)    The bufnr() of the requested buffer.
-function! s:MarkbarModel._getOrInitBufferCache(buffer_no) abort dict
+function! markbar#MarkbarModel#_getOrInitBufferCache(buffer_no) abort dict
     call markbar#ensure#IsNumber(a:buffer_no)
     let l:cache = get(l:self._buffer_caches, a:buffer_no, 0)
     if empty(l:cache)
@@ -201,11 +207,12 @@ function! s:MarkbarModel._getOrInitBufferCache(buffer_no) abort dict
     endif
     return l:cache
 endfunction
+let s:MarkbarModel._getOrInitBufferCache = function('markbar#MarkbarModel#_getOrInitBufferCache')
 
 " RETURNS:  (markbar#BufferCache)   BufferCache for the requested buffer.
 " DETAILS:  Throws an exception if a matching BufferCache isn't found.
 " PARAM:    buffer_no   (v:t_number)    The bufnr() of the requested buffer.
-function! s:MarkbarModel.getBufferCache(buffer_no) abort dict
+function! markbar#MarkbarModel#getBufferCache(buffer_no) abort dict
     call markbar#ensure#IsNumber(a:buffer_no)
     let l:cache = get(l:self._buffer_caches, a:buffer_no, 0)
     if empty(l:cache)
@@ -213,20 +220,22 @@ function! s:MarkbarModel.getBufferCache(buffer_no) abort dict
     endif
     return l:cache
 endfunction
+let s:MarkbarModel.getBufferCache = function('markbar#MarkbarModel#getBufferCache')
 
 " RETURNS:  (v:t_bool)  `v:true` if a cache was removed, `v:false` otherwise.
-function! s:MarkbarModel.evictBufferCache(buffer_no) abort dict
+function! markbar#MarkbarModel#evictBufferCache(buffer_no) abort dict
     if !has_key(l:self._buffer_caches, a:buffer_no)
         return v:false
     endif
     call remove(l:self._buffer_caches, a:buffer_no)
     return v:true
 endfunction
+let s:MarkbarModel.evictBufferCache = function('markbar#MarkbarModel#evictBufferCache')
 
 " DETAILS:  Update BufferCaches for the current buffer and for global marks.
 "           Creates BufferCaches for the current buffer and global marks if
 "           they don't yet exist.
-function! s:MarkbarModel.updateCurrentAndGlobal() abort dict
+function! markbar#MarkbarModel#updateCurrentAndGlobal() abort dict
     let l:bufnr = bufnr('%')
     let l:cur_buffer_cache = l:self._getOrInitBufferCache(l:bufnr)
     "                                                     ^ This is bufnr('%')
@@ -259,3 +268,4 @@ function! s:MarkbarModel.updateCurrentAndGlobal() abort dict
     call l:cur_buffer_cache.updateContexts(l:max_num_context)
     call l:global_buffer_cache.updateContexts(l:max_num_context)
 endfunction
+let s:MarkbarModel.updateCurrentAndGlobal = function('markbar#MarkbarModel#updateCurrentAndGlobal')

--- a/autoload/markbar/MarkbarTextGenerator.vim
+++ b/autoload/markbar/MarkbarTextGenerator.vim
@@ -19,7 +19,7 @@ endfunction
 " RETURNS:  (v:t_list)  Text content for the markbar as a list of strings.
 " PARAM:    locals      `marks_dict` for local marks from a markbar#BufferCache.
 " PARAM:    globals     Ditto, but for global marks.
-function! s:MarkbarTextGenerator.getText(local_marks, global_marks) abort dict
+function! markbar#MarkbarTextGenerator#getText(local_marks, global_marks) abort dict
     call markbar#ensure#IsDictionary(a:local_marks)
     call markbar#ensure#IsDictionary(a:global_marks)
 
@@ -94,9 +94,10 @@ function! s:MarkbarTextGenerator.getText(local_marks, global_marks) abort dict
 
     return l:lines
 endfunction
+let s:MarkbarTextGenerator.getText = function('markbar#MarkbarTextGenerator#getText')
 
 " RETURNS:  (v:t_string)    Section heading for the given mark.
-function! s:MarkbarTextGenerator.getMarkHeading(mark) abort dict
+function! markbar#MarkbarTextGenerator#getMarkHeading(mark) abort dict
     call markbar#ensure#IsClass(a:mark, 'MarkData')
     let l:suffix = ' '
 
@@ -155,3 +156,4 @@ function! s:MarkbarTextGenerator.getMarkHeading(mark) abort dict
 
     return printf("['%s]:%s", a:mark.getMarkChar(), l:suffix)
 endfunction
+let s:MarkbarTextGenerator.getMarkHeading = function('markbar#MarkbarTextGenerator#getMarkHeading')

--- a/autoload/markbar/MarkbarView.vim
+++ b/autoload/markbar/MarkbarView.vim
@@ -40,7 +40,7 @@ endfunction
 " PARAM:    size    (v:t_number)    The width of the markbar in columns if
 "                                   opened in a vertical split; the height of
 "                                   the markbar in lines, otherwise.
-function! s:MarkbarView.openMarkbar(open_position, open_vertical, size) abort dict
+function! markbar#MarkbarView#openMarkbar(open_position, open_vertical, size) abort dict
     if !exists('b:is_markbar')
         " only save the window state if we aren't already in the markbar
         call l:self._saveWinState()
@@ -60,10 +60,11 @@ function! s:MarkbarView.openMarkbar(open_position, open_vertical, size) abort di
     endif
     call l:self._setMarkbarWindowSettings(l:markbar_buffer)
 endfunction
+let s:MarkbarView.openMarkbar = function('markbar#MarkbarView#openMarkbar')
 
 " DETAILS:  Close markbars without calling _restoreWinState, which would move
 "           the cursor.
-function! s:MarkbarView._closeMarkbar() abort dict
+function! markbar#MarkbarView#_closeMarkbar() abort dict
     let l:markbar_buffers = l:self.getOpenMarkbars()
     if empty(l:markbar_buffers)
         return v:false
@@ -73,20 +74,22 @@ function! s:MarkbarView._closeMarkbar() abort dict
     endfor
     return v:true
 endfunction
+let s:MarkbarView._closeMarkbar = function('markbar#MarkbarView#_closeMarkbar')
 
 " BRIEF:    Close markbars open in the current tab and restore old window state.
 " RETURNS:  (v:t_bool)      `v:true` if a markbar was actually closed,
 "                           `v:false` otherwise.
-function! s:MarkbarView.closeMarkbar() abort dict
+function! markbar#MarkbarView#closeMarkbar() abort dict
     if !l:self._closeMarkbar()
         return v:false
     endif
     call l:self._restoreWinState()
     return v:true
 endfunction
+let s:MarkbarView.closeMarkbar = function('markbar#MarkbarView#closeMarkbar')
 
 " RETURNS:  (v:t_bool)  `v:true` if a markbar window is open in the current tab.
-function! s:MarkbarView.markbarIsOpenCurrentTab() abort dict
+function! markbar#MarkbarView#markbarIsOpenCurrentTab() abort dict
     let l:tab_buffers = tabpagebuflist()
     for l:bufnr in l:tab_buffers
         if getbufvar(l:bufnr, 'is_markbar')
@@ -95,10 +98,11 @@ function! s:MarkbarView.markbarIsOpenCurrentTab() abort dict
     endfor
     return v:false
 endfunction
+let s:MarkbarView.markbarIsOpenCurrentTab = function('markbar#MarkbarView#markbarIsOpenCurrentTab')
 
 " RETURNS:  (v:t_list)      A list of buffer numbers corresponding to all
 "                           markbar buffers open in the current tab.
-function! s:MarkbarView.getOpenMarkbars() abort dict
+function! markbar#MarkbarView#getOpenMarkbars() abort dict
     let l:tab_buffers = tabpagebuflist()
     let l:markbar_buffers = []
     for l:bufnr in l:tab_buffers
@@ -108,10 +112,11 @@ function! s:MarkbarView.getOpenMarkbars() abort dict
     endfor
     return l:markbar_buffers
 endfunction
+let s:MarkbarView.getOpenMarkbars = function('markbar#MarkbarView#getOpenMarkbars')
 
 " RETURNS:  (v:t_number)    |bufnr| of the markbar buffer.
 " DETAILS:  Creates a markbar buffer if one does not yet exist.
-function! s:MarkbarView.getMarkbarBuffer() abort dict
+function! markbar#MarkbarView#getMarkbarBuffer() abort dict
     if !bufexists(l:self._markbar_buffer)
         let l:bufname = markbar#settings#MarkbarBufferName()
         " escape special characters and create new
@@ -121,19 +126,22 @@ function! s:MarkbarView.getMarkbarBuffer() abort dict
     endif
     return l:self._markbar_buffer
 endfunction
+let s:MarkbarView.getMarkbarBuffer = function('markbar#MarkbarView#getMarkbarBuffer')
 
 " RETURNS:  (v:t_number)    The window ID of the 'markbar buffer', or -1 if
 "                           the window doesn't exist in the current tab page.
 " DETAILS:  Creates a markbar buffer if one does not yet exist.
-function! s:MarkbarView.getMarkbarWinID() abort dict
+function! markbar#MarkbarView#getMarkbarWinID() abort dict
     return bufwinid(l:self.getMarkbarBuffer())
 endfunction
+let s:MarkbarView.getMarkbarWinID = function('markbar#MarkbarView#getMarkbarWinID')
 
 " BRIEF:    Move cursor to the start of the given line in the current buffer.
 " PARAM:    line    (v:t_number)    The target line number.
-function! s:MarkbarView._moveCursorToLine(line) abort dict
+function! markbar#MarkbarView#_moveCursorToLine(line) abort dict
     execute 'silent normal! ' . a:line . 'G0'
 endfunction
+let s:MarkbarView._moveCursorToLine = function('markbar#MarkbarView#_moveCursorToLine')
 
 " BRIEF:    Jump to the currently selected mark
 " DETAILS:  Requires that the window containing the most recent active buffer
@@ -141,13 +149,14 @@ endfunction
 " PARAM:    goto_exact  (v:t_bool)  Whether to go to the line *and column* of
 "                                   the selected mark (`v:true`) or just the
 "                                   line (`v:false`).
-function! s:MarkbarView.goToSelectedMark(goto_exact) abort dict
+function! markbar#MarkbarView#goToSelectedMark(goto_exact) abort dict
     let l:selected_mark = l:self.getCurrentMarkHeading()
     if !len(l:selected_mark)
         return
     endif
     call l:self.goToMark(l:selected_mark, a:goto_exact)
 endfunction
+let s:MarkbarView.goToSelectedMark = function('markbar#MarkbarView#goToSelectedMark')
 
 " BRIEF:    Jump to the the mark given.
 " DETAILS:  Requires that the window containing the most recent active buffer
@@ -156,8 +165,7 @@ endfunction
 " PARAM:    goto_exact  (v:t_bool)  Whether to go to the line *and column* of
 "                                   the selected mark (`v:true`) or just the
 "                                   line (`v:false`).
-function! s:MarkbarView.goToMark(mark, goto_exact) abort dict
-
+function! markbar#MarkbarView#goToMark(mark, goto_exact) abort dict
     let l:active_buffer = l:self._markbar_model.getActiveBuffer()
     let l:mark_is_quote = a:mark ==# "'" || a:mark ==# '`'
 
@@ -212,10 +220,11 @@ function! s:MarkbarView.goToMark(mark, goto_exact) abort dict
         call l:self._closeMarkbar()
     endif
 endfunction
+let s:MarkbarView.goToMark = function('markbar#MarkbarView#goToMark')
 
 " BRIEF:    Move the cursor to the line of the given mark in the markbar.
 " DETAILS:  Prints an error message if the given mark could not be found.
-function! s:MarkbarView.selectMark(mark) abort dict
+function! markbar#MarkbarView#selectMark(mark) abort dict
     let l:line_no = l:self._getSpecificMarkHeadingLine(a:mark)
     if !l:line_no
         echohl WarningMsg
@@ -225,11 +234,12 @@ function! s:MarkbarView.selectMark(mark) abort dict
     endif
     call l:self._moveCursorToLine(l:line_no)
 endfunction
+let s:MarkbarView.selectMark = function('markbar#MarkbarView#selectMark')
 
 " BRIEF:    Move the cursor to the section heading of the next mark.
 " PARAM:    count   (v:t_number)    Move forward this many headings. Defaults
 "                                   to 1.
-function! s:MarkbarView.cycleToNextMark(...) abort dict
+function! markbar#MarkbarView#cycleToNextMark(...) abort dict
     let l:count = get(a:, 1, 1)
     if l:count <=# 0
         throw printf('Bad count: %s', l:count)
@@ -240,10 +250,11 @@ function! s:MarkbarView.cycleToNextMark(...) abort dict
         let l:i += 1
     endwhile
 endfunction
+let s:MarkbarView.cycleToNextMark = function('markbar#MarkbarView#cycleToNextMark')
 
 " BRIEF:    Move the cursor to the section heading of the previous mark.
 " PARAM:    count   (v:t_number)    Move back this many headings. Defaults to 1.
-function! s:MarkbarView.cycleToPreviousMark(...) abort dict
+function! markbar#MarkbarView#cycleToPreviousMark(...) abort dict
     let l:count = get(a:, 1, 1)
     if l:count <=# 0
         throw printf('Bad count: %s', l:count)
@@ -254,31 +265,35 @@ function! s:MarkbarView.cycleToPreviousMark(...) abort dict
         let l:i += 1
     endwhile
 endfunction
+let s:MarkbarView.cycleToPreviousMark = function('markbar#MarkbarView#cycleToPreviousMark')
 
 " RETURNS:  (v:t_string)    The 'currently selected' mark, or an empty string
 "                           if no mark is selected.
-function! s:MarkbarView.getCurrentMarkHeading() abort dict
+function! markbar#MarkbarView#getCurrentMarkHeading() abort dict
     return getline(l:self.getCurrentMarkHeadingLine())[2]
 endfunction
+let s:MarkbarView.getCurrentMarkHeading = function('markbar#MarkbarView#getCurrentMarkHeading')
 
 " RETURNS:  (v:t_number)    The line number of the 'currently selected' mark.
-function! s:MarkbarView.getCurrentMarkHeadingLine() abort dict
+function! markbar#MarkbarView#getCurrentMarkHeadingLine() abort dict
     let l:cur_heading_no = search(
         \ markbar#constants#MARK_HEADING_SEARCH_PATTERN(), 'bnc', 1)
     return l:cur_heading_no
 endfunction
+let s:MarkbarView.getCurrentMarkHeadingLine = function('markbar#MarkbarView#getCurrentMarkHeadingLine')
 
 " RETURNS:  (v:t_number)    The line number of the mark heading below the
 "                           'currently selected' mark.
-function! s:MarkbarView._getNextMarkHeadingLine() abort dict
+function! markbar#MarkbarView#_getNextMarkHeadingLine() abort dict
     let l:cur_heading_no = search(
         \ markbar#constants#MARK_HEADING_SEARCH_PATTERN(), 'n', 0)
     return l:cur_heading_no
 endfunction
+let s:MarkbarView._getNextMarkHeadingLine = function('markbar#MarkbarView#_getNextMarkHeadingLine')
 
 " RETURNS:  (v:t_number)    The line number of the mark heading above the
 "                           'currently selected' mark.
-function! s:MarkbarView._getPreviousMarkHeadingLine() abort dict
+function! markbar#MarkbarView#_getPreviousMarkHeadingLine() abort dict
     let l:searched_from_line = getcurpos()[1]
     " if the cursor is on a mark header, but right of column 0, then search
     " will return the current line; skip the match if that happens
@@ -286,18 +301,20 @@ function! s:MarkbarView._getPreviousMarkHeadingLine() abort dict
         \ markbar#constants#MARK_HEADING_SEARCH_PATTERN(), 'bn', 0)
     return l:cur_heading_no
 endfunction
+let s:MarkbarView._getPreviousMarkHeadingLine = function('markbar#MarkbarView#_getPreviousMarkHeadingLine')
 
 " RETURNS:  (v:t_number)    The line number of the heading corresponding to
 "                           the requested mark, if it exists; 0, otherwise.
-function! s:MarkbarView._getSpecificMarkHeadingLine(mark) abort dict
+function! markbar#MarkbarView#_getSpecificMarkHeadingLine(mark) abort dict
     let l:heading_no = search(
         \ markbar#constants#MARK_SPECIFIC_HEADING_SEARCH_PATTERN(a:mark),
         \ 'bnc', 0)
     return l:heading_no
 endfunction
+let s:MarkbarView._getSpecificMarkHeadingLine = function('markbar#MarkbarView#_getSpecificMarkHeadingLine')
 
 " BRIEF:    Set buffer-local settings for the given markbar buffer.
-function! s:MarkbarView._setMarkbarBufferSettings(buffer_expr) abort dict
+function! markbar#MarkbarView#_setMarkbarBufferSettings(buffer_expr) abort dict
     if !bufexists(a:buffer_expr)
         throw printf('Buffer does not exist: %s', a:buffer_expr)
     endif
@@ -314,9 +331,10 @@ function! s:MarkbarView._setMarkbarBufferSettings(buffer_expr) abort dict
 
     call setbufvar(a:buffer_expr,      'is_markbar',         1)
 endfunction
+let s:MarkbarView._setMarkbarBufferSettings = function('markbar#MarkbarView#_setMarkbarBufferSettings')
 
 " EFFECTS:  Set window-local settings for the given markbar buffer.
-function! s:MarkbarView._setMarkbarWindowSettings(buffer_expr) abort dict
+function! markbar#MarkbarView#_setMarkbarWindowSettings(buffer_expr) abort dict
     if !bufexists(a:buffer_expr)
         throw printf('Buffer does not exist: %s', a:buffer_expr)
     endif
@@ -337,10 +355,11 @@ function! s:MarkbarView._setMarkbarWindowSettings(buffer_expr) abort dict
 
     call setwinvar(l:winnr,      'is_markbar',         1)
 endfunction
+let s:MarkbarView._setMarkbarWindowSettings = function('markbar#MarkbarView#_setMarkbarWindowSettings')
 
 " BRIEF:    Save the current window number and window state.
 " DETAILS:  If the current window is a markbar window, throw an exception.
-function! s:MarkbarView._saveWinState() abort dict
+function! markbar#MarkbarView#_saveWinState() abort dict
     if exists('b:is_markbar')  " we're inside a markbar window
       throw 'Tried to save winstate from inside markbar!'
     endif
@@ -350,6 +369,7 @@ function! s:MarkbarView._saveWinState() abort dict
     let l:self._saved_num_win = winnr('$')
     let l:self._saved_tabpage_nr = tabpagenr()
 endfunction
+let s:MarkbarView._saveWinState = function('markbar#MarkbarView#_saveWinState')
 
 " BRIEF:    Restore the last-saved window state, if it exists and is valid.
 " DETAILS:  Returns the cursor to the saved window number, restores the old
@@ -357,7 +377,7 @@ endfunction
 "           Only works if markbar is on the same tabpage, and the windows on
 "           the screen are the same as they were during the last call to
 "           `_saveWinState`.
-function! s:MarkbarView._restoreWinState() abort dict
+function! markbar#MarkbarView#_restoreWinState() abort dict
     if tabpagenr() !=# l:self._saved_tabpage_nr
         return
     elseif winnr('$') !=# l:self._saved_num_win
@@ -372,3 +392,4 @@ function! s:MarkbarView._restoreWinState() abort dict
     execute l:self._win_resize_cmd
     call winrestview(l:self._saved_view)
 endfunction
+let s:MarkbarView._restoreWinState = function('markbar#MarkbarView#_restoreWinState')

--- a/autoload/markbar/ShaDaRosters.vim
+++ b/autoload/markbar/ShaDaRosters.vim
@@ -31,17 +31,18 @@ endfunction
 
 " BRIEF:    Populate ShaDaRosters object with mark names from viminfo/ShaDa.
 " DETAILS:  Must be called after viminfo/ShaDa have been read.
-function! s:ShaDaRosters.populate(global_roster, local_rosters) abort dict
+function! markbar#ShaDaRosters#populate(global_roster, local_rosters) abort dict
     call markbar#ensure#IsDictionary(a:global_roster)
     call markbar#ensure#IsDictionary(a:local_rosters)
     call extend(l:self._global_marks_to_names, a:global_roster, 'force')
     call extend(l:self._filepaths_to_rosters, a:local_rosters, 'force')
 endfunction
+let s:ShaDaRosters.populate = function('markbar#ShaDaRosters#populate')
 
 " DETAILS:  Write global roster into {new_global_roster}. Write local rosters
 "           for files in {new_oldfiles_list} into {new_local_rosters}.
-function! s:ShaDaRosters.writeRosters(new_oldfiles, new_global_roster,
-                                    \ new_local_rosters) abort dict
+function! markbar#ShaDaRosters#writeRosters(new_oldfiles, new_global_roster,
+                                          \ new_local_rosters) abort dict
     call markbar#ensure#IsList(a:new_oldfiles)
     call markbar#ensure#IsDictionary(a:new_global_roster)
     call markbar#ensure#IsDictionary(a:new_local_rosters)
@@ -62,6 +63,7 @@ function! s:ShaDaRosters.writeRosters(new_oldfiles, new_global_roster,
         let a:new_local_rosters[l:filepath] = l:local_rosters
     endfor
 endfunction
+let s:ShaDaRosters.writeRosters = function('markbar#ShaDaRosters#writeRosters')
 
 " DETAILS:  - Type-check {mark_char} and {filepath}.
 "           - Throw an exception if {filepath} is 0 (denoting the global
@@ -88,7 +90,7 @@ endfunction
 
 " DETAILS:  Return a local roster for the {filepath}, or the global roster if
 "           {filepath} is 0. Default-initialize a roster if none exists.
-function! s:ShaDaRosters.rosterFor(filepath) abort dict
+function! markbar#ShaDaRosters#rosterFor(filepath) abort dict
     if a:filepath isnot 0
         call markbar#ensure#IsString(a:filepath)
     endif
@@ -102,12 +104,13 @@ function! s:ShaDaRosters.rosterFor(filepath) abort dict
     endif
     return l:roster
 endfunction
+let s:ShaDaRosters.rosterFor = function('markbar#ShaDaRosters#rosterFor')
 
 " DETAILS:  - Set {new_name} for {mark_char} in the file {filepath}.
 "           - A {filepath} of 0 corresponds to the global mark roster.
 "           - If {new_name} is the empty string, then {mark_char} is removed
 "           from the roster.
-function! s:ShaDaRosters.setName(filepath, mark_char, new_name) abort dict
+function! markbar#ShaDaRosters#setName(filepath, mark_char, new_name) abort dict
     call s:ValidateMarkCharForFilepath(a:mark_char, a:filepath)
     call markbar#ensure#IsString(a:new_name)
     let l:roster = l:self.rosterFor(a:filepath)
@@ -119,11 +122,12 @@ function! s:ShaDaRosters.setName(filepath, mark_char, new_name) abort dict
         endif
     endif
 endfunction
+let s:ShaDaRosters.setName = function('markbar#ShaDaRosters#setName')
 
 " DETAILS:  - Returns the name for {mark_char} in the file {filepath}.
 "           - A {filepath} of 0 corresponds to the global mark roster.
 "           - Returns an empty string if an entry isn't found.
-function! s:ShaDaRosters.getName(filepath, mark_char) abort dict
+function! markbar#ShaDaRosters#getName(filepath, mark_char) abort dict
     call s:ValidateMarkCharForFilepath(a:mark_char, a:filepath)
     let l:roster = l:self.rosterFor(a:filepath)
     if l:roster is v:null
@@ -131,15 +135,17 @@ function! s:ShaDaRosters.getName(filepath, mark_char) abort dict
     endif
     return get(l:roster, a:mark_char, '')
 endfunction
+let s:ShaDaRosters.getName = function('markbar#ShaDaRosters#getName')
 
 " DETAILS:  Change the filename for a given local roster.
 "           - The global roster cannot be modified in this way.
 "           - {old_filepath} and {new_filepath} must be strings.
-function! s:ShaDaRosters.changeRosterFilename(old_filepath,
-                                            \ new_filepath) abort dict
+function! markbar#ShaDaRosters#changeRosterFilename(old_filepath,
+                                                  \ new_filepath) abort dict
     call markbar#ensure#IsString(a:old_filepath)
     call markbar#ensure#IsString(a:new_filepath)
     let l:roster = l:self.rosterFor(a:old_filepath)
     call remove(l:self._filepaths_to_rosters, a:old_filepath)
     let l:self._filepaths_to_rosters[a:new_filepath] = l:roster
 endfunction
+let s:ShaDaRosters.changeRosterFilename = function('markbar#ShaDaRosters#changeRosterFilename')

--- a/autoload/markbar/settings.vim
+++ b/autoload/markbar/settings.vim
@@ -46,8 +46,10 @@ function! markbar#settings#PersistMarkNames() abort
         if !l:will_save_globals
             echoerr '(vim-markbar) WARNING: g:markbar_persist_mark_names is '
                 \ . 'v:true, but won''t work because viminfo-!/shada-! is not '
-                \ . 'set! `set viminfo+=!` in vim or `set shada+=!` in neovim '
-                \ . 'to fix this.'
+                \ . 'set! Add `set viminfo+=!` to .vimrc in vim (or add '
+                \ . '`set shada+=!` to .vimrc in neovim) to fix this, or '
+                \ . '`let g:markbar_persist_mark_names = v:false` to silence '
+                \ . 'this error message.'
         endif
     endif
     call s:AssertType(

--- a/plugin/vim-markbar.vim
+++ b/plugin/vim-markbar.vim
@@ -124,7 +124,14 @@ endfunction
 ""
 " Code to be run (only once) when markbar exits.
 function! s:MarkbarVimLeave() abort
-    if markbar#settings#PersistMarkNames()
+    " try-catch to avoid an annoying/superfluous error message to the user
+    " that's briefly visible as Vim is closing
+    try
+        let l:persist_mark_names = markbar#settings#PersistMarkNames()
+    catch /Vim(echoerr)/
+        let l:persist_mark_names = v:false
+    endtry
+    if l:persist_mark_names
         call s:SerializeRosters()
     endif
 endfunction

--- a/test/standalone-test-peekaboo.vader
+++ b/test/standalone-test-peekaboo.vader
@@ -187,6 +187,12 @@ Execute (Go-direct-to-mark doesn't clobber the close-markbar mapping):
 Then:
   let g:markbar_close_peekaboo_mapping = '<Esc>'
 
+Do (Peekaboo markbar doesn't open from visual mode):
+  :edit! 10lines.txt\<cr>
+  gg0v`A"ay
+Then:
+  AssertEqual 'first ', @a
+
 Execute (Test Mark Highlighting, Backtick):
   let g:markbar_enable_mark_highlighting = v:true
   normal `

--- a/test/standalone-test-sequential-persist-mark-names-errors.vader/01-standalone-test-sequential-persist-mark-names-errors.vader
+++ b/test/standalone-test-sequential-persist-mark-names-errors.vader/01-standalone-test-sequential-persist-mark-names-errors.vader
@@ -1,0 +1,11 @@
+" This exists as a "standalone sequential" test because only those tests
+" specify a shadafile/viminfofile; when shadafile is NONE,
+" g:markbar_persist_mark_names is always v:false, and associated warning
+" messages won't trigger.
+
+Include: helpers.vader
+
+Execute (Error message shows when shada omits !):
+  call SetShada("'100,<50,s10,h")
+  AssertThrows call g:MarkbarVimEnter()
+  AssertEqual g:persist_mark_names_err_msg, g:vader_exception

--- a/test/standalone-test-sequential-persist-mark-names-errors.vader/02-standalone-test-sequential-persist-mark-names-errors.vader
+++ b/test/standalone-test-sequential-persist-mark-names-errors.vader/02-standalone-test-sequential-persist-mark-names-errors.vader
@@ -1,0 +1,5 @@
+Include: helpers.vader
+
+Execute (No error message shows when shada includes !):
+  call SetShada("!,'100,<50,s10,h")
+  call g:MarkbarVimEnter()

--- a/test/standalone-test-sequential-persist-mark-names-errors.vader/03-standalone-test-sequential-persist-mark-names-errors.vader
+++ b/test/standalone-test-sequential-persist-mark-names-errors.vader/03-standalone-test-sequential-persist-mark-names-errors.vader
@@ -1,0 +1,5 @@
+Include: helpers.vader
+
+Execute (No error message shows when shada includes ! in the middle):
+  call SetShada("'100,<50,!,s10,h")
+  call g:MarkbarVimEnter()

--- a/test/standalone-test-sequential-persist-mark-names-errors.vader/04-standalone-test-sequential-persist-mark-names-errors.vader
+++ b/test/standalone-test-sequential-persist-mark-names-errors.vader/04-standalone-test-sequential-persist-mark-names-errors.vader
@@ -1,0 +1,6 @@
+Include: helpers.vader
+
+Execute (No error message when g:markbar_persist_mark_names is v:false):
+  call SetShada("'100,<50,s10,h")
+  let g:markbar_persist_mark_names = v:false
+  call g:MarkbarVimEnter()

--- a/test/standalone-test-sequential-persist-mark-names-errors.vader/helpers.vader
+++ b/test/standalone-test-sequential-persist-mark-names-errors.vader/helpers.vader
@@ -1,0 +1,17 @@
+Execute (Set test helpers):
+
+  function! SetShada(new_value) abort
+    if has('nvim')
+      let &shada = a:new_value
+    else
+      let &viminfo = a:new_value
+    endif
+  endfunction
+
+  let g:persist_mark_names_err_msg =
+      \ 'Vim(echoerr):(vim-markbar) WARNING: g:markbar_persist_mark_names is '
+      \ . 'v:true, but won''t work because viminfo-!/shada-! is not '
+      \ . 'set! Add `set viminfo+=!` to .vimrc in vim (or add '
+      \ . '`set shada+=!` to .vimrc in neovim) to fix this, or '
+      \ . '`let g:markbar_persist_mark_names = v:false` to silence '
+      \ . 'this error message.'

--- a/test/test-MarkbarModel.vader
+++ b/test/test-MarkbarModel.vader
@@ -51,6 +51,7 @@ Execute (MarkbarModel: Add More Global Marks; Add Local Marks):
   execute '10mark c'
   execute '15mark b'
   execute '20mark a'
+  let g:filepath_30lines = expand('%:p')
 
   call g:markbar_model.updateCurrentAndGlobal()
 Then:


### PR DESCRIPTION
- Mention `g:markbar_persist_mark_names` more visibly in README and make its associated error message more helpful.
- Add tests for `g:markbar_persist_mark_names`'s error messages.
- Stop using `numbered-function` for object-oriented programming, because it makes callstacks unreadable and makes function breakpoints difficult to work with (ref: https://vi.stackexchange.com/a/20277).