### PR TITLE
Use getpos() instead of `redir`ecting :marks

### DIFF
--- a/autoload/markbar/MarkbarTextGenerator.vim
+++ b/autoload/markbar/MarkbarTextGenerator.vim
@@ -79,9 +79,9 @@ function! markbar#MarkbarTextGenerator#getText(local_marks, global_marks) abort 
             while l:j <# l:end
                 let l:line = l:full_context[l:j]
                 if l:j ==# l:mark_line_idx
-                    let l:colno = (l:jump_like_backtick) ?
-                        \ l:mark.getColumnNo() : matchstrpos(l:line, '\S')[1]
-                    let l:parts = markbar#helpers#SplitString(l:line, l:colno)
+                    let l:col_idx = (l:jump_like_backtick) ?
+                        \ l:mark.getColumnNo() - 1 : matchstrpos(l:line, '\S')[1]
+                    let l:parts = markbar#helpers#SplitString(l:line, l:col_idx)
                     let l:line = l:parts[0].l:marker.l:parts[1]
                 endif
                 call add(l:lines, l:indent_block . l:line)

--- a/autoload/markbar/MarkbarView.vim
+++ b/autoload/markbar/MarkbarView.vim
@@ -179,7 +179,7 @@ function! markbar#MarkbarView#goToMark(mark, goto_exact) abort dict
                     \.getMark("'")
             \ )
             let l:mark_line = l:targ_mark.getLineNo()
-            let l:mark_col  = l:targ_mark.getColumnNo() + 1
+            let l:mark_col  = l:targ_mark.getColumnNo()
         catch /mark not found in cache/
             call markbar#MarkbarView#MarkNotSet(a:mark)
             return

--- a/test/standalone-test-openmarkbar.vader
+++ b/test/standalone-test-openmarkbar.vader
@@ -50,17 +50,17 @@ Then:
 
 Expect:
   " Press ? for help
-  ['A]: 10lines.txt [l: 1, c: 5]
+  ['A]: 10lines.txt [l: 1, c: 6]
       ~
       first line
       second line
 
-  ['B]: 10lines.txt [l: 5, c: 5]
+  ['B]: 10lines.txt [l: 5, c: 6]
       fourth line
       fifth line
       sixth line
 
-  ['C]: 10lines.txt [l: 10, c: 5]
+  ['C]: 10lines.txt [l: 10, c: 6]
       ninth line
       tenth line
       ~
@@ -86,17 +86,17 @@ Expect:
   " c: reset mark's name
   " d: delete mark
   " -----------------------
-  ['A]: 10lines.txt [l: 1, c: 5]
+  ['A]: 10lines.txt [l: 1, c: 6]
       ~
       first line
       second line
 
-  ['B]: 10lines.txt [l: 5, c: 5]
+  ['B]: 10lines.txt [l: 5, c: 6]
       fourth line
       fifth line
       sixth line
 
-  ['C]: 10lines.txt [l: 10, c: 5]
+  ['C]: 10lines.txt [l: 10, c: 6]
       ninth line
       tenth line
       ~
@@ -116,17 +116,17 @@ Expect:
   " c: reset mark's name
   " d: delete mark
   " -----------------------
-  ['A]: 10lines.txt [l: 1, c: 5]
+  ['A]: 10lines.txt [l: 1, c: 6]
       ~
       first line
       second line
 
-  ['B]: 10lines.txt [l: 5, c: 5]
+  ['B]: 10lines.txt [l: 5, c: 6]
       fourth line
       fifth line
       sixth line
 
-  ['C]: 10lines.txt [l: 10, c: 5]
+  ['C]: 10lines.txt [l: 10, c: 6]
       ninth line
       tenth line
       ~
@@ -169,17 +169,17 @@ Expect:
   " c: reset mark's name
   " d: delete mark
   " -----------------------
-  ['A]: 10lines.txt [l: 1, c: 5]
+  ['A]: 10lines.txt [l: 1, c: 6]
       ~
       first line
       second line
 
-  ['B]: 10lines.txt [l: 5, c: 5]
+  ['B]: 10lines.txt [l: 5, c: 6]
       fourth line
       fifth line
       sixth line
 
-  ['C]: 10lines.txt [l: 10, c: 5]
+  ['C]: 10lines.txt [l: 10, c: 6]
       ninth line
       tenth line
       ~
@@ -188,17 +188,17 @@ Do (? closes verbose help after opening):
   Mo?
 Expect:
   " Press ? for help
-  ['A]: 10lines.txt [l: 1, c: 5]
+  ['A]: 10lines.txt [l: 1, c: 6]
       ~
       first line
       second line
 
-  ['B]: 10lines.txt [l: 5, c: 5]
+  ['B]: 10lines.txt [l: 5, c: 6]
       fourth line
       fifth line
       sixth line
 
-  ['C]: 10lines.txt [l: 10, c: 5]
+  ['C]: 10lines.txt [l: 10, c: 6]
       ninth line
       tenth line
       ~
@@ -216,17 +216,17 @@ Do (Re-Open Closed Markbar (E499 Check)):
   Mo
 Expect:
   " Press ? for help
-  ['A]: 10lines.txt [l: 1, c: 5]
+  ['A]: 10lines.txt [l: 1, c: 6]
       ~
       first line
       second line
 
-  ['B]: 10lines.txt [l: 5, c: 5]
+  ['B]: 10lines.txt [l: 5, c: 6]
       fourth line
       fifth line
       sixth line
 
-  ['C]: 10lines.txt [l: 10, c: 5]
+  ['C]: 10lines.txt [l: 10, c: 6]
       ninth line
       tenth line
       ~
@@ -239,17 +239,17 @@ Then:
   " AssertEqual num_windows, len(tabpagebuflist())
 Expect:
   " Press ? for help
-  ['A]: 10lines.txt [l: 1, c: 5]
+  ['A]: 10lines.txt [l: 1, c: 6]
       ~
       first line
       second line
 
-  ['B]: 10lines.txt [l: 5, c: 5]
+  ['B]: 10lines.txt [l: 5, c: 6]
       fourth line
       fifth line
       sixth line
 
-  ['C]: 10lines.txt [l: 10, c: 5]
+  ['C]: 10lines.txt [l: 10, c: 6]
       ninth line
       tenth line
       ~
@@ -277,17 +277,17 @@ Execute (:bdelete Markbar):
   normal Mo
 Expect:
   " Press ? for help
-  ['A]: 10lines.txt [l: 1, c: 5]
+  ['A]: 10lines.txt [l: 1, c: 6]
       ~
       first line
       second line
 
-  ['B]: 10lines.txt [l: 5, c: 5]
+  ['B]: 10lines.txt [l: 5, c: 6]
       fourth line
       fifth line
       sixth line
 
-  ['C]: 10lines.txt [l: 10, c: 5]
+  ['C]: 10lines.txt [l: 10, c: 6]
       ninth line
       tenth line
       ~
@@ -301,17 +301,17 @@ Then:
   AssertEqual 'markbar', &filetype
 Expect:
   " Press ? for help
-  ['A]: 10lines.txt [l: 1, c: 5]
+  ['A]: 10lines.txt [l: 1, c: 6]
       ~
       first line
       second line
 
-  ['B]: 10lines.txt [l: 5, c: 5]
+  ['B]: 10lines.txt [l: 5, c: 6]
       fourth line
       fifth line
       sixth line
 
-  ['C]: 10lines.txt [l: 10, c: 5]
+  ['C]: 10lines.txt [l: 10, c: 6]
       ninth line
       tenth line
       ~
@@ -325,17 +325,17 @@ Then:
   AssertEqual 'markbar', &filetype
 Expect:
   " Press ? for help
-  ['A]: 10lines.txt [l: 1, c: 5]
+  ['A]: 10lines.txt [l: 1, c: 6]
       ~
       first line
       second line
 
-  ['B]: 10lines.txt [l: 5, c: 5]
+  ['B]: 10lines.txt [l: 5, c: 6]
       fourth line
       fifth line
       sixth line
 
-  ['C]: 10lines.txt [l: 10, c: 5]
+  ['C]: 10lines.txt [l: 10, c: 6]
       ninth line
       tenth line
       ~
@@ -460,17 +460,17 @@ Execute (Explicitly Rename Mark):
   normal Mo
 Expect:
   " Press ? for help
-  ['A]: 10lines.txt [l: 1, c: 5]
+  ['A]: 10lines.txt [l: 1, c: 6]
       ~
       first line
       second line
 
-  ['B]: New Name 10lines.txt [l: 5, c: 5]
+  ['B]: New Name 10lines.txt [l: 5, c: 6]
       fourth line
       fifth line
       sixth line
 
-  ['C]: 10lines.txt [l: 10, c: 5]
+  ['C]: 10lines.txt [l: 10, c: 6]
       ninth line
       tenth line
       ~
@@ -482,17 +482,17 @@ Do (Reset Mark Name):
   Mo
 Expect:
   " Press ? for help
-  ['A]: 10lines.txt [l: 1, c: 5]
+  ['A]: 10lines.txt [l: 1, c: 6]
       ~
       first line
       second line
 
-  ['B]: 10lines.txt [l: 5, c: 5]
+  ['B]: 10lines.txt [l: 5, c: 6]
       fourth line
       fifth line
       sixth line
 
-  ['C]: 10lines.txt [l: 10, c: 5]
+  ['C]: 10lines.txt [l: 10, c: 6]
       ninth line
       tenth line
       ~
@@ -503,12 +503,12 @@ Do (Delete Mark):
   5Gd
 Expect:
   " Press ? for help
-  ['B]: 10lines.txt [l: 5, c: 5]
+  ['B]: 10lines.txt [l: 5, c: 6]
       fourth line
       fifth line
       sixth line
 
-  ['C]: 10lines.txt [l: 10, c: 5]
+  ['C]: 10lines.txt [l: 10, c: 6]
       ninth line
       tenth line
       ~
@@ -520,17 +520,17 @@ Do (Set Local Mark, Toggle Markbar Open):
   Mt
 Expect:
   " Press ? for help
-  ['a]: (l: 1, c: 5)
+  ['a]: (l: 1, c: 6)
       ~
       first line
       second line
 
-  ['B]: 10lines.txt [l: 5, c: 5]
+  ['B]: 10lines.txt [l: 5, c: 6]
       fourth line
       fifth line
       sixth line
 
-  ['C]: 10lines.txt [l: 10, c: 5]
+  ['C]: 10lines.txt [l: 10, c: 6]
       ninth line
       tenth line
       ~
@@ -542,12 +542,12 @@ Do (Delete Local Mark):
   d
 Expect:
   " Press ? for help
-  ['B]: 10lines.txt [l: 5, c: 5]
+  ['B]: 10lines.txt [l: 5, c: 6]
       fourth line
       fifth line
       sixth line
 
-  ['C]: 10lines.txt [l: 10, c: 5]
+  ['C]: 10lines.txt [l: 10, c: 6]
       ninth line
       tenth line
       ~
@@ -574,17 +574,17 @@ Execute (Backtick-like mark location is highlighted when highlighting is turned 
   normal Mo
 Expect:
   " Press ? for help
-  ['A]: 10lines.txt [l: 1, c: 5]
+  ['A]: 10lines.txt [l: 1, c: 6]
       ~
       first➜ line
       second line
 
-  ['B]: 10lines.txt [l: 5, c: 0]
+  ['B]: 10lines.txt [l: 5, c: 1]
       fourth line
       ➜fifth line
       sixth line
 
-  ['C]: 10lines.txt [l: 10, c: 9]
+  ['C]: 10lines.txt [l: 10, c: 10]
       ninth line
       tenth lin➜e
       ~
@@ -594,17 +594,17 @@ Execute (Apostrophe-like mark location is highlighted when highlighting is turne
   normal Mo
 Expect:
   " Press ? for help
-  ['A]: 10lines.txt [l: 1, c: 5]
+  ['A]: 10lines.txt [l: 1, c: 6]
       ~
       ➜first line
       second line
 
-  ['B]: 10lines.txt [l: 5, c: 0]
+  ['B]: 10lines.txt [l: 5, c: 1]
       fourth line
       ➜fifth line
       sixth line
 
-  ['C]: 10lines.txt [l: 10, c: 9]
+  ['C]: 10lines.txt [l: 10, c: 10]
       ninth line
       ➜tenth line
       ~
@@ -622,27 +622,27 @@ Execute (Default mark names format can be customized):
   normal Mo
 Expect:
   " Press ? for help
-  ['a]: 10lines.txt {c: 0, l: 2}
+  ['a]: 10lines.txt {c: 1, l: 2}
       first line
       ➜second line
       third line
 
-  ['b]: 10lines.txt {c: 10, l: 4}
+  ['b]: 10lines.txt {c: 11, l: 4}
       third line
       ➜fourth line
       fifth line
 
-  ['A]: fname: 10lines.txt, col: 5, line: 1
+  ['A]: fname: 10lines.txt, col: 6, line: 1
       ~
       ➜first line
       second line
 
-  ['B]: fname: 10lines.txt, col: 0, line: 5
+  ['B]: fname: 10lines.txt, col: 1, line: 5
       fourth line
       ➜fifth line
       sixth line
 
-  ['C]: fname: 10lines.txt, col: 9, line: 10
+  ['C]: fname: 10lines.txt, col: 10, line: 10
       ninth line
       ➜tenth line
       ~
@@ -660,19 +660,19 @@ Execute (g:markbar_num_lines_context controls how many context lines are shown):
 
 Expect:
   " Press ? for help
-  ['a]: 10lines.txt {c: 0, l: 2}
+  ['a]: 10lines.txt {c: 1, l: 2}
       ➜second line
       third line
 
-  ['b]: 10lines.txt {c: 10, l: 4}
+  ['b]: 10lines.txt {c: 11, l: 4}
       fourth lin➜e
       fifth line
 
-  ['A]: fname: 10lines.txt, col: 5, line: 1
+  ['A]: fname: 10lines.txt, col: 6, line: 1
 
-  ['B]: fname: 10lines.txt, col: 0, line: 5
+  ['B]: fname: 10lines.txt, col: 1, line: 5
 
-  ['C]: fname: 10lines.txt, col: 9, line: 10
+  ['C]: fname: 10lines.txt, col: 10, line: 10
   
 Execute (Reconfigured context length displays properly with highlighting disabled):
   " test an alternate code path
@@ -682,19 +682,19 @@ Execute (Reconfigured context length displays properly with highlighting disable
 
 Expect:
   " Press ? for help
-  ['a]: 10lines.txt {c: 0, l: 2}
+  ['a]: 10lines.txt {c: 1, l: 2}
       second line
       third line
 
-  ['b]: 10lines.txt {c: 10, l: 4}
+  ['b]: 10lines.txt {c: 11, l: 4}
       fourth line
       fifth line
 
-  ['A]: fname: 10lines.txt, col: 5, line: 1
+  ['A]: fname: 10lines.txt, col: 6, line: 1
 
-  ['B]: fname: 10lines.txt, col: 0, line: 5
+  ['B]: fname: 10lines.txt, col: 1, line: 5
 
-  ['C]: fname: 10lines.txt, col: 9, line: 10
+  ['C]: fname: 10lines.txt, col: 10, line: 10
   
 
 Execute (Context displays properly when file marks show more context than local marks):
@@ -708,27 +708,27 @@ Execute (Context displays properly when file marks show more context than local 
   normal Mo
 Expect:
   " Press ? for help
-  ['a]: 10lines.txt {c: 0, l: 2}
+  ['a]: 10lines.txt {c: 1, l: 2}
       second line
       third line
 
-  ['b]: 10lines.txt {c: 10, l: 4}
+  ['b]: 10lines.txt {c: 11, l: 4}
       fourth line
       fifth line
 
-  ['A]: fname: 10lines.txt, col: 5, line: 1
+  ['A]: fname: 10lines.txt, col: 6, line: 1
       ~
       first line
       second line
       third line
 
-  ['B]: fname: 10lines.txt, col: 0, line: 5
+  ['B]: fname: 10lines.txt, col: 1, line: 5
       fourth line
       fifth line
       sixth line
       seventh line
 
-  ['C]: fname: 10lines.txt, col: 9, line: 10
+  ['C]: fname: 10lines.txt, col: 10, line: 10
       ninth line
       tenth line
       ~

--- a/test/standalone-test-peekaboo.vader
+++ b/test/standalone-test-peekaboo.vader
@@ -78,17 +78,17 @@ Then:
 
 Expect:
   " Press ? for help
-  ['A]: 10lines.txt [l: 1, c: 5]
+  ['A]: 10lines.txt [l: 1, c: 6]
     ~
     first line
     second line
 
-  ['B]: 10lines.txt [l: 5, c: 0]
+  ['B]: 10lines.txt [l: 5, c: 1]
     fourth line
     fifth line
     sixth line
 
-  ['C]: 10lines.txt [l: 10, c: 0]
+  ['C]: 10lines.txt [l: 10, c: 1]
     ninth line
     tenth line
     ~
@@ -198,17 +198,17 @@ Execute (Test Mark Highlighting, Backtick):
   normal `
 Expect:
   " Press ? for help
-  ['A]: 10lines.txt [l: 1, c: 5]
+  ['A]: 10lines.txt [l: 1, c: 6]
     ~
     first➜ line
     second line
 
-  ['B]: 10lines.txt [l: 5, c: 0]
+  ['B]: 10lines.txt [l: 5, c: 1]
     fourth line
     ➜fifth line
     sixth line
 
-  ['C]: 10lines.txt [l: 10, c: 0]
+  ['C]: 10lines.txt [l: 10, c: 1]
     ninth line
     ➜tenth line
     ~
@@ -218,17 +218,17 @@ Execute (Apostrophe is highlighted like backtick when jump_to_exact_position is 
   normal '
 Expect:
   " Press ? for help
-  ['A]: 10lines.txt [l: 1, c: 5]
+  ['A]: 10lines.txt [l: 1, c: 6]
     ~
     first➜ line
     second line
 
-  ['B]: 10lines.txt [l: 5, c: 0]
+  ['B]: 10lines.txt [l: 5, c: 1]
     fourth line
     ➜fifth line
     sixth line
 
-  ['C]: 10lines.txt [l: 10, c: 0]
+  ['C]: 10lines.txt [l: 10, c: 1]
     ninth line
     ➜tenth line
     ~
@@ -238,17 +238,17 @@ Execute (Apostrophe is highlighted like apostrophe when jump_to_exact_position i
   normal '
 Expect:
   " Press ? for help
-  ['A]: 10lines.txt [l: 1, c: 5]
+  ['A]: 10lines.txt [l: 1, c: 6]
     ~
     ➜first line
     second line
 
-  ['B]: 10lines.txt [l: 5, c: 0]
+  ['B]: 10lines.txt [l: 5, c: 1]
     fourth line
     ➜fifth line
     sixth line
 
-  ['C]: 10lines.txt [l: 10, c: 0]
+  ['C]: 10lines.txt [l: 10, c: 1]
     ninth line
     ➜tenth line
     ~
@@ -428,22 +428,22 @@ Execute (View Single-Quote Mark):
   normal '
 Expect:
   " Press ? for help
-  ['']: (l: 1, c: 5) Last Jump
+  ['']: (l: 1, c: 6) Last Jump
     ~
     first line
     second line
 
-  ['A]: 10lines.txt [l: 1, c: 5]
+  ['A]: 10lines.txt [l: 1, c: 6]
     ~
     first line
     second line
 
-  ['B]: 10lines.txt [l: 5, c: 0]
+  ['B]: 10lines.txt [l: 5, c: 1]
     fourth line
     fifth line
     sixth line
 
-  ['C]: 10lines.txt [l: 10, c: 0]
+  ['C]: 10lines.txt [l: 10, c: 1]
     ninth line
     tenth line
     ~
@@ -502,19 +502,19 @@ Do (Set Local Marks):
 
 Expect (Num Context Defaults to Same as Ordinary Markbar):
   " Press ? for help
-  ['a]: (l: 2, c: 0)
+  ['a]: (l: 2, c: 1)
     second line
     third line
 
-  ['b]: (l: 4, c: 10)
+  ['b]: (l: 4, c: 11)
     fourth line
     fifth line
 
-  ['A]: 10lines.txt [l: 1, c: 5]
+  ['A]: 10lines.txt [l: 1, c: 6]
 
-  ['B]: 10lines.txt [l: 5, c: 0]
+  ['B]: 10lines.txt [l: 5, c: 1]
 
-  ['C]: 10lines.txt [l: 10, c: 0]
+  ['C]: 10lines.txt [l: 10, c: 1]
   
 Execute (Show Correct Num Lines When File Shows More than Local):
   let g:markbar_num_lines_context = {
@@ -526,19 +526,19 @@ Execute (Show Correct Num Lines When File Shows More than Local):
 
 Expect (Correct Numbers of Lines of Context):
   " Press ? for help
-  ['a]: (l: 2, c: 0)
+  ['a]: (l: 2, c: 1)
 
-  ['b]: (l: 4, c: 10)
+  ['b]: (l: 4, c: 11)
 
-  ['A]: 10lines.txt [l: 1, c: 5]
+  ['A]: 10lines.txt [l: 1, c: 6]
     first line
     second line
 
-  ['B]: 10lines.txt [l: 5, c: 0]
+  ['B]: 10lines.txt [l: 5, c: 1]
     fifth line
     sixth line
 
-  ['C]: 10lines.txt [l: 10, c: 0]
+  ['C]: 10lines.txt [l: 10, c: 1]
     tenth line
     ~
   
@@ -554,21 +554,21 @@ Execute (Separately Configure Normal and Peekaboo):
 
 Expect (Correct Numbers of Lines of Context):
   " Press ? for help
-  ['a]: (l: 2, c: 0)
+  ['a]: (l: 2, c: 1)
     ~
     first line
     second line
     third line
     fourth line
 
-  ['b]: (l: 4, c: 10)
+  ['b]: (l: 4, c: 11)
     second line
     third line
     fourth line
     fifth line
     sixth line
 
-  ['A]: 10lines.txt [l: 1, c: 5]
+  ['A]: 10lines.txt [l: 1, c: 6]
     ~
     ~
     ~
@@ -578,7 +578,7 @@ Expect (Correct Numbers of Lines of Context):
     fourth line
     fifth line
 
-  ['B]: 10lines.txt [l: 5, c: 0]
+  ['B]: 10lines.txt [l: 5, c: 1]
     second line
     third line
     fourth line
@@ -588,7 +588,7 @@ Expect (Correct Numbers of Lines of Context):
     eighth line
     ninth line
 
-  ['C]: 10lines.txt [l: 10, c: 0]
+  ['C]: 10lines.txt [l: 10, c: 1]
     seventh line
     eighth line
     ninth line
@@ -605,21 +605,21 @@ Execute (Enable Mark Highlighting):
 
 Expect (Correct Output, Backtick-Like):
   " Press ? for help
-  ['a]: (l: 2, c: 0)
+  ['a]: (l: 2, c: 1)
     ~
     first line
     ➜second line
     third line
     fourth line
 
-  ['b]: (l: 4, c: 10)
+  ['b]: (l: 4, c: 11)
     second line
     third line
     fourth lin➜e
     fifth line
     sixth line
 
-  ['A]: 10lines.txt [l: 1, c: 5]
+  ['A]: 10lines.txt [l: 1, c: 6]
     ~
     ~
     ~
@@ -629,7 +629,7 @@ Expect (Correct Output, Backtick-Like):
     fourth line
     fifth line
 
-  ['B]: 10lines.txt [l: 5, c: 0]
+  ['B]: 10lines.txt [l: 5, c: 1]
     second line
     third line
     fourth line
@@ -639,7 +639,7 @@ Expect (Correct Output, Backtick-Like):
     eighth line
     ninth line
 
-  ['C]: 10lines.txt [l: 10, c: 0]
+  ['C]: 10lines.txt [l: 10, c: 1]
     seventh line
     eighth line
     ninth line

--- a/test/standalone-test-sequential-delmarks.vader/01-standalone-test-sequential-delmarks.vader
+++ b/test/standalone-test-sequential-delmarks.vader/01-standalone-test-sequential-delmarks.vader
@@ -7,8 +7,8 @@ Do (Set Marks, Open Markbar):
   Mo
 Expect:
   " Press ? for help
-  ['a]: (l: 2, c: 0)
-  ['b]: (l: 4, c: 10)
-  ['A]: 10lines.txt [l: 1, c: 5]
-  ['B]: 10lines.txt [l: 5, c: 5]
-  ['C]: 10lines.txt [l: 10, c: 5]
+  ['a]: (l: 2, c: 1)
+  ['b]: (l: 4, c: 11)
+  ['A]: 10lines.txt [l: 1, c: 6]
+  ['B]: 10lines.txt [l: 5, c: 6]
+  ['C]: 10lines.txt [l: 10, c: 6]

--- a/test/standalone-test-sequential-name-persistence.vader/01-standalone-test-sequential-name-persistence.vader
+++ b/test/standalone-test-sequential-name-persistence.vader/01-standalone-test-sequential-name-persistence.vader
@@ -7,11 +7,11 @@ Do (Set Marks in 10lines.txt, Open Markbar):
   Mo
 Expect:
   " Press ? for help
-  ['a]: (l: 2, c: 0)
-  ['b]: (l: 4, c: 10)
-  ['A]: 10lines.txt [l: 1, c: 5]
-  ['B]: 10lines.txt [l: 5, c: 5]
-  ['C]: 10lines.txt [l: 10, c: 5]
+  ['a]: (l: 2, c: 1)
+  ['b]: (l: 4, c: 11)
+  ['A]: 10lines.txt [l: 1, c: 6]
+  ['B]: 10lines.txt [l: 5, c: 6]
+  ['C]: 10lines.txt [l: 10, c: 6]
 
 Execute (Rename Marks in 10lines.txt):
   edit! 10lines.txt
@@ -25,11 +25,11 @@ Execute (Rename Marks in 10lines.txt):
   normal MtMt
 Expect:
   " Press ? for help
-  ['a]: (l: 2, c: 0) 10lines.txt a
-  ['b]: (l: 4, c: 10) 10lines.txt b
-  ['A]: 10lines.txt A 10lines.txt [l: 1, c: 5]
-  ['B]: 10lines.txt B 10lines.txt [l: 5, c: 5]
-  ['C]: 10lines.txt C 10lines.txt [l: 10, c: 5]
+  ['a]: (l: 2, c: 1) 10lines.txt a
+  ['b]: (l: 4, c: 11) 10lines.txt b
+  ['A]: 10lines.txt A 10lines.txt [l: 1, c: 6]
+  ['B]: 10lines.txt B 10lines.txt [l: 5, c: 6]
+  ['C]: 10lines.txt C 10lines.txt [l: 10, c: 6]
 
 Do (Set Marks in 30lines.txt, Open Markbar):
   :edit! 30lines.txt\<cr>
@@ -38,12 +38,12 @@ Do (Set Marks in 30lines.txt, Open Markbar):
   Mo
 Expect:
   " Press ? for help
-  ['a]: (l: 1, c: 5)
-  ['b]: (l: 5, c: 5)
-  ['c]: (l: 10, c: 5)
-  ['A]: 10lines.txt A 10lines.txt [l: 1, c: 5]
-  ['B]: 10lines.txt B 10lines.txt [l: 5, c: 5]
-  ['C]: 10lines.txt C 30lines.txt [l: 20, c: 0]
+  ['a]: (l: 1, c: 6)
+  ['b]: (l: 5, c: 6)
+  ['c]: (l: 10, c: 6)
+  ['A]: 10lines.txt A 10lines.txt [l: 1, c: 6]
+  ['B]: 10lines.txt B 10lines.txt [l: 5, c: 6]
+  ['C]: 10lines.txt C 30lines.txt [l: 20, c: 1]
 
 Execute (Rename Marks in 30lines.txt):
   edit! 30lines.txt
@@ -55,9 +55,9 @@ Execute (Rename Marks in 30lines.txt):
   normal MtMt
 Expect:
   " Press ? for help
-  ['a]: (l: 1, c: 5) 30lines.txt a
-  ['b]: (l: 5, c: 5) 30lines.txt b
-  ['c]: (l: 10, c: 5)
-  ['A]: 10lines.txt A 10lines.txt [l: 1, c: 5]
-  ['B]: 10lines.txt-B 10lines.txt [l: 5, c: 5]
-  ['C]: 10lines.txt C 30lines.txt [l: 20, c: 0]
+  ['a]: (l: 1, c: 6) 30lines.txt a
+  ['b]: (l: 5, c: 6) 30lines.txt b
+  ['c]: (l: 10, c: 6)
+  ['A]: 10lines.txt A 10lines.txt [l: 1, c: 6]
+  ['B]: 10lines.txt-B 10lines.txt [l: 5, c: 6]
+  ['C]: 10lines.txt C 30lines.txt [l: 20, c: 1]

--- a/test/standalone-test-sequential-name-persistence.vader/02-standalone-test-sequential-name-persistence.vader
+++ b/test/standalone-test-sequential-name-persistence.vader/02-standalone-test-sequential-name-persistence.vader
@@ -5,23 +5,23 @@ Do (Open Markbar for 10lines.txt):
   Mo
 Expect:
   " Press ? for help
-  ['a]: (l: 2, c: 0) 10lines.txt a
-  ['b]: (l: 4, c: 10) 10lines.txt b
-  ['A]: 10lines.txt A 10lines.txt [l: 1, c: 5]
-  ['B]: 10lines.txt-B 10lines.txt [l: 5, c: 5]
-  ['C]: 10lines.txt C 30lines.txt [l: 20, c: 0]
+  ['a]: (l: 2, c: 1) 10lines.txt a
+  ['b]: (l: 4, c: 11) 10lines.txt b
+  ['A]: 10lines.txt A 10lines.txt [l: 1, c: 6]
+  ['B]: 10lines.txt-B 10lines.txt [l: 5, c: 6]
+  ['C]: 10lines.txt C 30lines.txt [l: 20, c: 1]
 
 Do (Open Markbar for 30lines.txt):
   :edit! 30lines.txt\<cr>
   Mo
 Expect:
   " Press ? for help
-  ['a]: (l: 1, c: 5) 30lines.txt a
-  ['b]: (l: 5, c: 5) 30lines.txt b
-  ['c]: (l: 10, c: 5)
-  ['A]: 10lines.txt A 10lines.txt [l: 1, c: 5]
-  ['B]: 10lines.txt-B 10lines.txt [l: 5, c: 5]
-  ['C]: 10lines.txt C 30lines.txt [l: 20, c: 0]
+  ['a]: (l: 1, c: 6) 30lines.txt a
+  ['b]: (l: 5, c: 6) 30lines.txt b
+  ['c]: (l: 10, c: 6)
+  ['A]: 10lines.txt A 10lines.txt [l: 1, c: 6]
+  ['B]: 10lines.txt-B 10lines.txt [l: 5, c: 6]
+  ['C]: 10lines.txt C 30lines.txt [l: 20, c: 1]
 
 Do (Delete a mark in 10lines.txt from the markbar):
   :edit! 10lines.txt\<cr>
@@ -29,10 +29,10 @@ Do (Delete a mark in 10lines.txt from the markbar):
   ggnd
 Expect:
   " Press ? for help
-  ['b]: (l: 4, c: 10) 10lines.txt b
-  ['A]: 10lines.txt A 10lines.txt [l: 1, c: 5]
-  ['B]: 10lines.txt-B 10lines.txt [l: 5, c: 5]
-  ['C]: 10lines.txt C 30lines.txt [l: 20, c: 0]
+  ['b]: (l: 4, c: 11) 10lines.txt b
+  ['A]: 10lines.txt A 10lines.txt [l: 1, c: 6]
+  ['B]: 10lines.txt-B 10lines.txt [l: 5, c: 6]
+  ['C]: 10lines.txt C 30lines.txt [l: 20, c: 1]
 
 Execute (Delete a local and global mark in 30lines.txt with delmarks):
   edit! 30lines.txt
@@ -45,7 +45,7 @@ Execute (Delete a local and global mark in 30lines.txt with delmarks):
   normal Mo
 Expect:
   " Press ? for help
-  ['a]: (l: 1, c: 5) 30lines.txt a
-  ['c]: (l: 10, c: 5)
-  ['A]: 10lines.txt A 10lines.txt [l: 1, c: 5]
-  ['B]: 10lines.txt-B 10lines.txt [l: 5, c: 5]
+  ['a]: (l: 1, c: 6) 30lines.txt a
+  ['c]: (l: 10, c: 6)
+  ['A]: 10lines.txt A 10lines.txt [l: 1, c: 6]
+  ['B]: 10lines.txt-B 10lines.txt [l: 5, c: 6]

--- a/test/standalone-test-sequential-name-persistence.vader/03-standalone-test-sequential-name-persistence.vader
+++ b/test/standalone-test-sequential-name-persistence.vader/03-standalone-test-sequential-name-persistence.vader
@@ -6,10 +6,10 @@ Do (Set mark a again in 10lines.txt and open markbar):
   Mo
 Expect (mark a does not inherit its name from before deletion):
   " Press ? for help
-  ['a]: (l: 1, c: 5)
-  ['b]: (l: 4, c: 10) 10lines.txt b
-  ['A]: 10lines.txt A 10lines.txt [l: 1, c: 5]
-  ['B]: 10lines.txt-B 10lines.txt [l: 5, c: 5]
+  ['a]: (l: 1, c: 6)
+  ['b]: (l: 4, c: 11) 10lines.txt b
+  ['A]: 10lines.txt A 10lines.txt [l: 1, c: 6]
+  ['B]: 10lines.txt-B 10lines.txt [l: 5, c: 6]
 
 Do (Set marks b, C again in 30lines.txt and open markbar):
   :edit! 30lines.txt\<cr>
@@ -18,12 +18,12 @@ Do (Set marks b, C again in 30lines.txt and open markbar):
   Mo
 Expect (marks b, C don't inherit their names from before deletion):
   " Press ? for help
-  ['a]: (l: 1, c: 5) 30lines.txt a
-  ['b]: (l: 30, c: 2)
-  ['c]: (l: 10, c: 5)
-  ['A]: 10lines.txt A 10lines.txt [l: 1, c: 5]
-  ['B]: 10lines.txt-B 10lines.txt [l: 5, c: 5]
-  ['C]: 30lines.txt [l: 25, c: 7]
+  ['a]: (l: 1, c: 6) 30lines.txt a
+  ['b]: (l: 30, c: 3)
+  ['c]: (l: 10, c: 6)
+  ['A]: 10lines.txt A 10lines.txt [l: 1, c: 6]
+  ['B]: 10lines.txt-B 10lines.txt [l: 5, c: 6]
+  ['C]: 30lines.txt [l: 25, c: 8]
 
 Execute (Save the file under a new name):
   edit 30lines.txt
@@ -32,12 +32,12 @@ Execute (Save the file under a new name):
   normal Mo
 Expect (Names from original file are preserved):
   " Press ? for help
-  ['a]: (l: 1, c: 5) 30lines.txt a
-  ['b]: (l: 30, c: 2)
-  ['c]: (l: 10, c: 5)
-  ['A]: 10lines.txt A 10lines.txt [l: 1, c: 5]
-  ['B]: 10lines.txt-B 10lines.txt [l: 5, c: 5]
-  ['C]: standalone-test-sequential-name-persistence.vader/thirtylines.temp [l: 25, c: 7]
+  ['a]: (l: 1, c: 6) 30lines.txt a
+  ['b]: (l: 30, c: 3)
+  ['c]: (l: 10, c: 6)
+  ['A]: 10lines.txt A 10lines.txt [l: 1, c: 6]
+  ['B]: 10lines.txt-B 10lines.txt [l: 5, c: 6]
+  ['C]: standalone-test-sequential-name-persistence.vader/thirtylines.temp [l: 25, c: 8]
 
 Execute (Rename and move the mark in the new file):
   edit standalone-test-sequential-name-persistence.vader/thirtylines.temp
@@ -49,9 +49,9 @@ Execute (Rename and move the mark in the new file):
   normal Mo
 Expect (Names are changed):
   " Press ? for help
-  ['a]: (l: 10, c: 8) thirtylines a
-  ['b]: (l: 30, c: 2)
-  ['c]: (l: 10, c: 5) thirtylines c
-  ['A]: 10lines.txt A 10lines.txt [l: 1, c: 5]
-  ['B]: thirtylines B standalone-test-sequential-name-persistence.vader/thirtylines.temp [l: 15, c: 4]
-  ['C]: standalone-test-sequential-name-persistence.vader/thirtylines.temp [l: 25, c: 7]
+  ['a]: (l: 10, c: 9) thirtylines a
+  ['b]: (l: 30, c: 3)
+  ['c]: (l: 10, c: 6) thirtylines c
+  ['A]: 10lines.txt A 10lines.txt [l: 1, c: 6]
+  ['B]: thirtylines B standalone-test-sequential-name-persistence.vader/thirtylines.temp [l: 15, c: 5]
+  ['C]: standalone-test-sequential-name-persistence.vader/thirtylines.temp [l: 25, c: 8]

--- a/test/standalone-test-sequential-name-persistence.vader/04-standalone-test-sequential-name-persistence.vader
+++ b/test/standalone-test-sequential-name-persistence.vader/04-standalone-test-sequential-name-persistence.vader
@@ -5,8 +5,8 @@ Execute (Reopen 30lines.txt):
   normal Mo
 Expect (Old mark names from before are preserved):
   " Press ? for help
-  ['a]: (l: 1, c: 5) 30lines.txt a
-  ['c]: (l: 10, c: 5)
-  ['A]: 10lines.txt A 10lines.txt [l: 1, c: 5]
-  ['B]: thirtylines B standalone-test-sequential-name-persistence.vader/thirtylines.temp [l: 15, c: 4]
-  ['C]: standalone-test-sequential-name-persistence.vader/thirtylines.temp [l: 25, c: 7]
+  ['a]: (l: 1, c: 6) 30lines.txt a
+  ['c]: (l: 10, c: 6)
+  ['A]: 10lines.txt A 10lines.txt [l: 1, c: 6]
+  ['B]: thirtylines B standalone-test-sequential-name-persistence.vader/thirtylines.temp [l: 15, c: 5]
+  ['C]: standalone-test-sequential-name-persistence.vader/thirtylines.temp [l: 25, c: 8]

--- a/test/test-BufferCache.vader
+++ b/test/test-BufferCache.vader
@@ -29,11 +29,11 @@ Execute (BufferCache: Populate Local Cache):
 Then:
   let g:bufno_50lines = bufnr('%')
   let buffer_marks = cache_50lines['marks_dict']
-  call AssertParsedCorrectly(['a',  '5', '0', '50lines.txt', g:filepath_50lines], buffer_marks['a'])
-  call AssertParsedCorrectly(['b', '15', '0', '50lines.txt', g:filepath_50lines], buffer_marks['b'])
-  call AssertParsedCorrectly(['c', '25', '0', '50lines.txt', g:filepath_50lines], buffer_marks['c'])
-  call AssertParsedCorrectly(['d', '35', '0', '50lines.txt', g:filepath_50lines], buffer_marks['d'])
-  call AssertParsedCorrectly(['e', '45', '0', '50lines.txt', g:filepath_50lines], buffer_marks['e'])
+  call AssertParsedCorrectly(['a',  5, 1, '50lines.txt', g:filepath_50lines], buffer_marks['a'])
+  call AssertParsedCorrectly(['b', 15, 1, '50lines.txt', g:filepath_50lines], buffer_marks['b'])
+  call AssertParsedCorrectly(['c', 25, 1, '50lines.txt', g:filepath_50lines], buffer_marks['c'])
+  call AssertParsedCorrectly(['d', 35, 1, '50lines.txt', g:filepath_50lines], buffer_marks['d'])
+  call AssertParsedCorrectly(['e', 45, 1, '50lines.txt', g:filepath_50lines], buffer_marks['e'])
 
 Execute (BufferCache: Populate Global Cache):
   execute 'normal! :e! #' . g:bufno_50lines . "\<cr>"
@@ -45,18 +45,18 @@ Execute (BufferCache: Populate Global Cache):
 Then:
   " check globals
   let buffer_marks = global_cache['marks_dict']
-  call AssertParsedCorrectly(['C', '30', '0', '50lines.txt', g:filepath_50lines], buffer_marks['C'])
-  call AssertParsedCorrectly(['D', '40', '0', '50lines.txt', g:filepath_50lines], buffer_marks['D'])
-  call AssertParsedCorrectly(['E', '50', '0', '50lines.txt', g:filepath_50lines], buffer_marks['E'])
+  call AssertParsedCorrectly(['C', 30, 1, '50lines.txt', g:filepath_50lines], buffer_marks['C'])
+  call AssertParsedCorrectly(['D', 40, 1, '50lines.txt', g:filepath_50lines], buffer_marks['D'])
+  call AssertParsedCorrectly(['E', 50, 1, '50lines.txt', g:filepath_50lines], buffer_marks['E'])
 
 Execute (BufferCache global marks populate correctly from different buffer):
   execute 'normal :edit! ' . '30lines.txt' . "\<cr>"
   call global_cache.updateCache(markbar#helpers#GetGlobalMarks(), '', '')
 Then:
   let buffer_marks = global_cache['marks_dict']
-  call AssertParsedCorrectly(['C', '30', '0', '50lines.txt', g:filepath_50lines], buffer_marks['C'])
-  call AssertParsedCorrectly(['D', '40', '0', '50lines.txt', g:filepath_50lines], buffer_marks['D'])
-  call AssertParsedCorrectly(['E', '50', '0', '50lines.txt', g:filepath_50lines], buffer_marks['E'])
+  call AssertParsedCorrectly(['C', 30, 1, '50lines.txt', g:filepath_50lines], buffer_marks['C'])
+  call AssertParsedCorrectly(['D', 40, 1, '50lines.txt', g:filepath_50lines], buffer_marks['D'])
+  call AssertParsedCorrectly(['E', 50, 1, '50lines.txt', g:filepath_50lines], buffer_marks['E'])
 
 Execute (BufferCache: Add More Global Marks; Add Local Marks):
   execute 'normal :edit! ' . '30lines.txt' . "\<cr>"
@@ -78,26 +78,26 @@ Execute (BufferCache: Add More Global Marks; Add Local Marks):
 
 Then:
   let buffer_marks = cache_30lines['marks_dict']
-  call AssertParsedCorrectly(['e',  '1', '0', '30lines.txt', g:filepath_30lines], buffer_marks['e'])
-  call AssertParsedCorrectly(['d',  '5', '0', '30lines.txt', g:filepath_30lines], buffer_marks['d'])
-  call AssertParsedCorrectly(['c', '10', '0', '30lines.txt', g:filepath_30lines], buffer_marks['c'])
-  call AssertParsedCorrectly(['b', '15', '0', '30lines.txt', g:filepath_30lines], buffer_marks['b'])
-  call AssertParsedCorrectly(['a', '20', '0', '30lines.txt', g:filepath_30lines], buffer_marks['a'])
+  call AssertParsedCorrectly(['e',  1, 1, '30lines.txt', g:filepath_30lines], buffer_marks['e'])
+  call AssertParsedCorrectly(['d',  5, 1, '30lines.txt', g:filepath_30lines], buffer_marks['d'])
+  call AssertParsedCorrectly(['c', 10, 1, '30lines.txt', g:filepath_30lines], buffer_marks['c'])
+  call AssertParsedCorrectly(['b', 15, 1, '30lines.txt', g:filepath_30lines], buffer_marks['b'])
+  call AssertParsedCorrectly(['a', 20, 1, '30lines.txt', g:filepath_30lines], buffer_marks['a'])
 
   " make sure that we didn't somehow overwrite these older ones
   let buffer_marks = cache_50lines['marks_dict']
-  call AssertParsedCorrectly(['a',  '5', '0', '50lines.txt', g:filepath_50lines], buffer_marks['a'])
-  call AssertParsedCorrectly(['b', '15', '0', '50lines.txt', g:filepath_50lines], buffer_marks['b'])
-  call AssertParsedCorrectly(['c', '25', '0', '50lines.txt', g:filepath_50lines], buffer_marks['c'])
-  call AssertParsedCorrectly(['d', '35', '0', '50lines.txt', g:filepath_50lines], buffer_marks['d'])
-  call AssertParsedCorrectly(['e', '45', '0', '50lines.txt', g:filepath_50lines], buffer_marks['e'])
+  call AssertParsedCorrectly(['a',  5, 1, '50lines.txt', g:filepath_50lines], buffer_marks['a'])
+  call AssertParsedCorrectly(['b', 15, 1, '50lines.txt', g:filepath_50lines], buffer_marks['b'])
+  call AssertParsedCorrectly(['c', 25, 1, '50lines.txt', g:filepath_50lines], buffer_marks['c'])
+  call AssertParsedCorrectly(['d', 35, 1, '50lines.txt', g:filepath_50lines], buffer_marks['d'])
+  call AssertParsedCorrectly(['e', 45, 1, '50lines.txt', g:filepath_50lines], buffer_marks['e'])
 
   let buffer_marks = global_cache['marks_dict']
-  call AssertParsedCorrectly(['A', '10', '0', '30lines.txt', g:filepath_30lines], buffer_marks['A'])
-  call AssertParsedCorrectly(['B', '20', '0', '30lines.txt', g:filepath_30lines], buffer_marks['B'])
-  call AssertParsedCorrectly(['C', '30', '0', '50lines.txt', g:filepath_50lines], buffer_marks['C'])
-  call AssertParsedCorrectly(['D', '40', '0', '50lines.txt', g:filepath_50lines], buffer_marks['D'])
-  call AssertParsedCorrectly(['E', '50', '0', '50lines.txt', g:filepath_50lines], buffer_marks['E'])
+  call AssertParsedCorrectly(['A', 10, 1, '30lines.txt', g:filepath_30lines], buffer_marks['A'])
+  call AssertParsedCorrectly(['B', 20, 1, '30lines.txt', g:filepath_30lines], buffer_marks['B'])
+  call AssertParsedCorrectly(['C', 30, 1, '50lines.txt', g:filepath_50lines], buffer_marks['C'])
+  call AssertParsedCorrectly(['D', 40, 1, '50lines.txt', g:filepath_50lines], buffer_marks['D'])
+  call AssertParsedCorrectly(['E', 50, 1, '50lines.txt', g:filepath_50lines], buffer_marks['E'])
 
 
 Execute (BufferCache: Fetch Contexts for Onscreen Buffer):

--- a/test/test-MarkData.vader
+++ b/test/test-MarkData.vader
@@ -1,239 +1,72 @@
-################################################################################
-# TrimMarksHeader tests
-################################################################################
-
-Execute (Empty Mark String):
-  let g:markstring = 'mark line  col file/text'
-  let g:result = markbar#helpers#TrimMarksHeader(g:markstring)
-Then:
-  AssertEqual '', g:result
-
-Execute (LF-Terminated Empty Mark String):
-  let g:markstring = "mark line  col file/text\n"
-  let g:result = markbar#helpers#TrimMarksHeader(g:markstring)
-Then:
-  AssertEqual '', g:result
-
-Execute (CRLF-Terminated Empty Mark String):
-  let g:markstring = "mark line  col file/text\r\n"
-  let g:result = markbar#helpers#TrimMarksHeader(g:markstring)
-Then:
-  AssertEqual '', g:result
-
-Execute (Leading Whitespace Mark String):
-  let g:markstring = "
-    \  \n \n \n mark line  col file/text\n
-    \ A     97    0 ~/plugin/vim-markbar/plugin/vim-markbar.vim\n
-  \ "
-  let g:result = markbar#helpers#TrimMarksHeader(g:markstring)
-Then:
-  let g:expected = "
-    \ A     97    0 ~/plugin/vim-markbar/plugin/vim-markbar.vim\n
-  \ "
-  AssertEqual g:expected, g:result
-
-Execute (Single Item Mark String):
-  let g:markstring = "
-    \ mark line  col file/text\n
-    \ A     97    0 ~/plugin/vim-markbar/plugin/vim-markbar.vim\n
-  \ "
-  let g:result = markbar#helpers#TrimMarksHeader(g:markstring)
-Then:
-  let g:expected = "
-    \ A     97    0 ~/plugin/vim-markbar/plugin/vim-markbar.vim\n
-  \ "
-  AssertEqual g:expected, g:result
-
-Execute (CRLF-Terminated Single Item Mark String):
-  let g:markstring = "
-    \ mark line  col file/text\n
-    \ A     97    0 ~/plugin/vim-markbar/plugin/vim-markbar.vim\r\n
-  \ "
-  let g:result = markbar#helpers#TrimMarksHeader(g:markstring)
-Then:
-  let g:expected = "
-    \ A     97    0 ~/plugin/vim-markbar/plugin/vim-markbar.vim\r\n
-  \ "
-  AssertEqual g:expected, g:result
-
-Execute (Two Item Mark String):
-  let g:markstring = "
-    \ mark line  col file/text\n
-    \ A     97    0 ~/plugin/vim-markbar/plugin/vim-markbar.vim\n
-    \ ]     24    0 Then:\n
-  \ "
-  let g:result = markbar#helpers#TrimMarksHeader(g:markstring)
-Then:
-  let g:expected = "
-    \ A     97    0 ~/plugin/vim-markbar/plugin/vim-markbar.vim\n
-    \ ]     24    0 Then:\n
-  \ "
-  AssertEqual g:expected, g:result
-
-Execute (Three Item Mark String):
-  let g:markstring = "
-    \ mark line  col file/text\n
-    \ A     97    0 ~/plugin/vim-markbar/plugin/vim-markbar.vim\n
-    \ ]     24    0 Then:\n
-    \ .     23    0\n
-  \ "
-  let g:result = markbar#helpers#TrimMarksHeader(g:markstring)
-Then:
-  let g:expected = "
-    \ A     97    0 ~/plugin/vim-markbar/plugin/vim-markbar.vim\n
-    \ ]     24    0 Then:\n
-    \ .     23    0\n
-  \ "
-  AssertEqual g:expected, g:result
-
-Execute (Multiitem Mark String):
-  let g:markstring = "
-    \ mark line  col file/text\n
-    \ A     97    0 ~/plugin/vim-markbar/plugin/vim-markbar.vim\n
-    \ [      1    0 The quick brown fox jumps over the lazy dog\n
-    \ ]     24    0 Then:\n
-    \ ^     23    2\n
-    \ .     23    0\n
-  \ "
-  let g:result = markbar#helpers#TrimMarksHeader(g:markstring)
-Then:
-  let g:expected = "
-    \ A     97    0 ~/plugin/vim-markbar/plugin/vim-markbar.vim\n
-    \ [      1    0 The quick brown fox jumps over the lazy dog\n
-    \ ]     24    0 Then:\n
-    \ ^     23    2\n
-    \ .     23    0\n
-  \ "
-  AssertEqual g:expected, g:result
-
-Execute (CRLF-Terminated Multiitem Mark String):
-  let g:markstring = "
-    \ mark line  col file/text\r\n
-    \ A     97    0 ~/plugin/vim-markbar/plugin/vim-markbar.vim\r\n
-    \ [      1    0 The quick brown fox jumps over the lazy dog\r\n
-    \ ]     24    0 Then:\r\n
-    \ ^     23    2\r\n
-    \ .     23    0\r\n
-  \ "
-  let g:result = markbar#helpers#TrimMarksHeader(g:markstring)
-Then:
-  let g:expected = "
-    \ A     97    0 ~/plugin/vim-markbar/plugin/vim-markbar.vim\r\n
-    \ [      1    0 The quick brown fox jumps over the lazy dog\r\n
-    \ ]     24    0 Then:\r\n
-    \ ^     23    2\r\n
-    \ .     23    0\r\n
-  \ "
-  AssertEqual g:expected, g:result
-
-Execute (Error-Check Already Trimmed):
-  let g:markstring = "
-    \ A     97    0 ~/plugin/vim-markbar/plugin/vim-markbar.vim\r\n
-    \ [      1    0 The quick brown fox jumps over the lazy dog\r\n
-    \ ]     24    0 Then:\r\n
-    \ ^     23    2\r\n
-    \ .     23    0\r\n
-  \ "
-Then:
-  AssertThrows markbar#helpers#TrimMarksHeader(g:markstring)
-
-Execute (Error-Check Already Trimmed Edge Case):
-  let g:markstring = "
-    \ [      1    0 The quick brown fox jumps over the lazy dog\r\n
-    \ ]     24    0 Then:\r\n
-    \ ^     23    2\r\n
-    \ a     97    0 mark line  col file/text\r\n
-    \ .     23    0\r\n
-  \ "
-Then:
-  AssertThrows markbar#helpers#TrimMarksHeader(g:markstring)
-
-
-################################################################################
-# MarkData tests
-################################################################################
-
-Execute (MarkData: Local Mark):
-  let g:markstring = "
-    \ a     97    0 mark line  col file/text\r\n
-  \ "
-  let g:result = markbar#MarkData#New(g:markstring, 'foobar.txt',
+Execute (MarkData constructs local alphabetic marks properly):
+  let g:result = markbar#MarkData#New('a', [0, 97, 1, 0], 'foobar.txt',
                                     \ '/foo/bar/foobar.txt')
 Then:
   AssertEqual 'MarkData', g:result['TYPE']
   AssertEqual 'a',  g:result.getMarkChar()
-  AssertEqual '97', g:result.getLineNo()
-  AssertEqual '0',  g:result.getColumnNo()
-  Assert           !g:result.isGlobal()
+  AssertEqual 97, g:result.getLineNo()
+  AssertEqual 1,  g:result.getColumnNo()
+  Assert          !g:result.isGlobal()
 
-Execute (MarkData: Non-Alphabetic Mark):
-  let g:markstring = "
-    \ [      1    0 The quick brown fox jumps over the lazy dog\n
-  \ "
-  let g:result = markbar#MarkData#New(g:markstring, 'foobar.txt',
+Execute (MarkData constructs non-alphabetic marks properly):
+  let g:result = markbar#MarkData#New('[', [0, 1, 1, 0], 'foobar.txt',
                                     \ '/foo/bar/foobar.txt')
 Then:
   AssertEqual 'MarkData', g:result['TYPE']
   AssertEqual '[', g:result.getMarkChar()
-  AssertEqual '1', g:result.getLineNo()
-  AssertEqual '0', g:result.getColumnNo()
+  AssertEqual 1,   g:result.getLineNo()
+  AssertEqual 1,   g:result.getColumnNo()
   Assert          !g:result.isGlobal()
 
-Execute (MarkData: Construct from 'Synthetic' Markstring):
-  normal! i12345
-  normal! viwy
+Execute (MarkData constructs [, ] marks properly):
   let left_bracket =
-    \ markbar#MarkData#New(markbar#helpers#MakeMarkString('['), 'foobar.txt',
+    \ markbar#MarkData#New('[', [0, 1, 1, 0], 'foobar.txt',
                          \ '/foo/bar/foobar.txt')
   let right_bracket =
-    \ markbar#MarkData#New(markbar#helpers#MakeMarkString(']'), 'foobar.txt',
+    \ markbar#MarkData#New(']', [0, 1, 5, 0], 'foobar.txt',
                          \ '/foo/bar/foobar.txt')
 Then:
   AssertEqual 'MarkData', g:result['TYPE']
-  AssertEqual '[',  left_bracket.getMarkChar()
-  AssertEqual '1',  left_bracket.getLineNo()
-  AssertEqual '1',  left_bracket.getColumnNo()
-  Assert           !left_bracket.isGlobal()
+  AssertEqual '[', left_bracket.getMarkChar()
+  AssertEqual 1,   left_bracket.getLineNo()
+  AssertEqual 1,   left_bracket.getColumnNo()
+  Assert          !left_bracket.isGlobal()
 
   AssertEqual 'MarkData', g:result['TYPE']
   AssertEqual ']',  right_bracket.getMarkChar()
-  AssertEqual '1',  right_bracket.getLineNo()
-  AssertEqual '5',  right_bracket.getColumnNo()
+  AssertEqual 1,    right_bracket.getLineNo()
+  AssertEqual 5,    right_bracket.getColumnNo()
   Assert           !right_bracket.isGlobal()
 
-Execute (MarkData: Global File Mark):
-  let g:markstring = "
-    \ D      64    31 The quick brown fox jumps over the lazy dog\r\n
-  \ "
-  let g:result = markbar#MarkData#New(g:markstring, 'foobar.txt',
+Execute (MarkData constructs global file marks properly):
+  let g:result = markbar#MarkData#New('D', [0, 64, 31, 0], 'foobar.txt',
                                     \ '/foo/bar/foobar.txt')
 Then:
   AssertEqual 'MarkData', g:result['TYPE']
   AssertEqual 'D',  g:result.getMarkChar()
-  AssertEqual '64', g:result.getLineNo()
-  AssertEqual '31', g:result.getColumnNo()
+  AssertEqual 64,   g:result.getLineNo()
+  AssertEqual 31,   g:result.getColumnNo()
   Assert            g:result.isGlobal()
 
-Execute (MarkData: ShaDa Numeric Mark):
-  let g:markstring = "
-    \ 8      19   5 The quick brown fox jumps over the lazy dog\n
-  \ "
-  let g:result = markbar#MarkData#New(g:markstring, 'foobar.txt',
+Execute (MarkData constructs numeric marks properly):
+  let g:result = markbar#MarkData#New('8', [0, 19, 5, 0], 'foobar.txt',
                                     \ '/foo/bar/foobar.txt')
 Then:
   AssertEqual 'MarkData', g:result['TYPE']
   AssertEqual '8',  g:result.getMarkChar()
-  AssertEqual '19', g:result.getLineNo()
-  AssertEqual '5',  g:result.getColumnNo()
+  AssertEqual 19,   g:result.getLineNo()
+  AssertEqual 5,    g:result.getColumnNo()
   Assert            g:result.isGlobal()
 
-Execute (MarkData: Error Check, Invalid Markstring):
-  let g:markstring = "
-    \ D      1  The quick brown fox jumps over the lazy dog\r\n
-  \ "
-Then:
-  AssertThrows markbar#MarkData#New(g:markstring, 'foobar.txt',
-                                    \ '/foo/bar/foobar.txt')
+Execute (MarkData throws when constructed with non-positive line or column number):
+  AssertThrows markbar#MarkData#New('D', [0, 0, 1, 0], 'foobar.txt',
+                                  \ '/foo/bar/foobar.txt')
+  AssertThrows markbar#MarkData#New('D', [0, 1, 0, 0], 'foobar.txt',
+                                  \ '/foo/bar/foobar.txt')
+
+Execute (MarkData throws when given badly formatted getpos output):
+  AssertThrows markbar#MarkData#New('D', [0, 1, 0], 'foobar.txt',
+                                  \ '/foo/bar/foobar.txt')
 
 Execute (MarkData gives proper names to "punctuation marks"):
   let g:marks_and_names = [
@@ -251,7 +84,7 @@ Execute (MarkData gives proper names to "punctuation marks"):
     \ ['}', 'Paragraph End'],
   \ ]
   for [g:mark, g:name] in g:marks_and_names
-    let g:markdata = markbar#MarkData#New(printf('%s 1 2 foobar', g:mark),
+    let g:markdata = markbar#MarkData#New(g:mark, [0, 1, 2, 0],
         \ 'foobar.txt', '/foo/bar/foobar.txt')
     AssertEqual g:name, g:markdata.getDefaultName()
   endfor

--- a/test/test-MarkbarModel.vader
+++ b/test/test-MarkbarModel.vader
@@ -19,11 +19,11 @@ Execute (MarkbarModel: Populate Local Cache):
 Then:
   let g:bufno_50lines = bufnr('%')
   let buffer_marks = g:markbar_model.getBufferCache(g:bufno_50lines)['marks_dict']
-  call AssertParsedCorrectly(['a',  '5', '0', '50lines.txt', g:filepath_50lines],   buffer_marks['a'])
-  call AssertParsedCorrectly(['b', '15', '0', '50lines.txt', g:filepath_50lines],   buffer_marks['b'])
-  call AssertParsedCorrectly(['c', '25', '0', '50lines.txt', g:filepath_50lines],   buffer_marks['c'])
-  call AssertParsedCorrectly(['d', '35', '0', '50lines.txt', g:filepath_50lines],   buffer_marks['d'])
-  call AssertParsedCorrectly(['e', '45', '0', '50lines.txt', g:filepath_50lines],   buffer_marks['e'])
+  call AssertParsedCorrectly(['a',  5, 1, '50lines.txt', g:filepath_50lines],   buffer_marks['a'])
+  call AssertParsedCorrectly(['b', 15, 1, '50lines.txt', g:filepath_50lines],   buffer_marks['b'])
+  call AssertParsedCorrectly(['c', 25, 1, '50lines.txt', g:filepath_50lines],   buffer_marks['c'])
+  call AssertParsedCorrectly(['d', 35, 1, '50lines.txt', g:filepath_50lines],   buffer_marks['d'])
+  call AssertParsedCorrectly(['e', 45, 1, '50lines.txt', g:filepath_50lines],   buffer_marks['e'])
 
 Execute (MarkbarModel: Populate Global Cache):
   " should still be on 50lines.txt, but just in case,
@@ -36,9 +36,9 @@ Then:
   " check globals
   let global_marks =
     \ g:markbar_model.getBufferCache(0)['marks_dict']
-  call AssertParsedCorrectly(['C', '30', '0', '50lines.txt', g:filepath_50lines],   global_marks['C'])
-  call AssertParsedCorrectly(['D', '40', '0', '50lines.txt', g:filepath_50lines],   global_marks['D'])
-  call AssertParsedCorrectly(['E', '50', '0', '50lines.txt', g:filepath_50lines],   global_marks['E'])
+  call AssertParsedCorrectly(['C', 30, 1, '50lines.txt', g:filepath_50lines],   global_marks['C'])
+  call AssertParsedCorrectly(['D', 40, 1, '50lines.txt', g:filepath_50lines],   global_marks['D'])
+  call AssertParsedCorrectly(['E', 50, 1, '50lines.txt', g:filepath_50lines],   global_marks['E'])
 
 Execute (MarkbarModel: Add More Global Marks; Add Local Marks):
   execute 'normal :edit! ' . '30lines.txt' . "\<cr>"
@@ -56,27 +56,27 @@ Execute (MarkbarModel: Add More Global Marks; Add Local Marks):
   call g:markbar_model.updateCurrentAndGlobal()
 Then:
   let buffer_marks = g:markbar_model.getBufferCache(g:bufno_30lines)['marks_dict']
-  call AssertParsedCorrectly(['e',  '1', '0', '30lines.txt', g:filepath_30lines],   buffer_marks['e'])
-  call AssertParsedCorrectly(['d',  '5', '0', '30lines.txt', g:filepath_30lines],   buffer_marks['d'])
-  call AssertParsedCorrectly(['c', '10', '0', '30lines.txt', g:filepath_30lines],   buffer_marks['c'])
-  call AssertParsedCorrectly(['b', '15', '0', '30lines.txt', g:filepath_30lines],   buffer_marks['b'])
-  call AssertParsedCorrectly(['a', '20', '0', '30lines.txt', g:filepath_30lines],   buffer_marks['a'])
+  call AssertParsedCorrectly(['e',  1, 1, '30lines.txt', g:filepath_30lines],   buffer_marks['e'])
+  call AssertParsedCorrectly(['d',  5, 1, '30lines.txt', g:filepath_30lines],   buffer_marks['d'])
+  call AssertParsedCorrectly(['c', 10, 1, '30lines.txt', g:filepath_30lines],   buffer_marks['c'])
+  call AssertParsedCorrectly(['b', 15, 1, '30lines.txt', g:filepath_30lines],   buffer_marks['b'])
+  call AssertParsedCorrectly(['a', 20, 1, '30lines.txt', g:filepath_30lines],   buffer_marks['a'])
 
   " make sure that we didn't somehow overwrite these older ones
   let buffer_marks = g:markbar_model.getBufferCache(g:bufno_50lines)['marks_dict']
-  call AssertParsedCorrectly(['a',  '5', '0', '50lines.txt', g:filepath_50lines],   buffer_marks['a'])
-  call AssertParsedCorrectly(['b', '15', '0', '50lines.txt', g:filepath_50lines],   buffer_marks['b'])
-  call AssertParsedCorrectly(['c', '25', '0', '50lines.txt', g:filepath_50lines],   buffer_marks['c'])
-  call AssertParsedCorrectly(['d', '35', '0', '50lines.txt', g:filepath_50lines],   buffer_marks['d'])
-  call AssertParsedCorrectly(['e', '45', '0', '50lines.txt', g:filepath_50lines],   buffer_marks['e'])
+  call AssertParsedCorrectly(['a',  5, 1, '50lines.txt', g:filepath_50lines],   buffer_marks['a'])
+  call AssertParsedCorrectly(['b', 15, 1, '50lines.txt', g:filepath_50lines],   buffer_marks['b'])
+  call AssertParsedCorrectly(['c', 25, 1, '50lines.txt', g:filepath_50lines],   buffer_marks['c'])
+  call AssertParsedCorrectly(['d', 35, 1, '50lines.txt', g:filepath_50lines],   buffer_marks['d'])
+  call AssertParsedCorrectly(['e', 45, 1, '50lines.txt', g:filepath_50lines],   buffer_marks['e'])
 
   let global_marks =
     \ g:markbar_model.getBufferCache(0)['marks_dict']
-  call AssertParsedCorrectly(['A', '10', '0', '30lines.txt', g:filepath_30lines],   global_marks['A'])
-  call AssertParsedCorrectly(['B', '20', '0', '30lines.txt', g:filepath_30lines],   global_marks['B'])
-  call AssertParsedCorrectly(['C', '30', '0', '50lines.txt', g:filepath_50lines],   global_marks['C'])
-  call AssertParsedCorrectly(['D', '40', '0', '50lines.txt', g:filepath_50lines],   global_marks['D'])
-  call AssertParsedCorrectly(['E', '50', '0', '50lines.txt', g:filepath_50lines],   global_marks['E'])
+  call AssertParsedCorrectly(['A', 10, 1, '30lines.txt', g:filepath_30lines],   global_marks['A'])
+  call AssertParsedCorrectly(['B', 20, 1, '30lines.txt', g:filepath_30lines],   global_marks['B'])
+  call AssertParsedCorrectly(['C', 30, 1, '50lines.txt', g:filepath_50lines],   global_marks['C'])
+  call AssertParsedCorrectly(['D', 40, 1, '50lines.txt', g:filepath_50lines],   global_marks['D'])
+  call AssertParsedCorrectly(['E', 50, 1, '50lines.txt', g:filepath_50lines],   global_marks['E'])
 
 Execute (BufferCache: Test Name Preservation Across Cache Updates):
   execute 'normal :edit! ' . '30lines.txt' . "\<cr>"

--- a/test/test-MarkbarTextGenerator.vader
+++ b/test/test-MarkbarTextGenerator.vader
@@ -47,8 +47,7 @@ Execute (MarkbarTextGenerator prints no marks with empty 'marks_to_display'):
   function! SynthesizeMark(mark_char, line_no, col_no, bufname,
                          \ filename, context) abort
     let l:mark = markbar#MarkData#New(
-        \ printf('%s %d %d foo bar foo', a:mark_char, a:line_no, a:col_no),
-        \ a:bufname, a:filename)
+        \ a:mark_char, [0, a:line_no, a:col_no, 0], a:bufname, a:filename)
     call l:mark.setContext(a:context)
     let l:mark.getFilename = function({a -> a}, [a:filename])
     return l:mark


### PR DESCRIPTION
Parsing the output of `:marks` fails when the `file/text` column contains literal newline keycodes, which might happen when pasting a recorded macro from a register into the current buffer, or when editing a binary file. Instead, retrieve active marks by calling `getpos()`.

The `col` column of `:marks` is one less than the column value returned by `getpos()`; update tests to reflect this.

Closes #42.