### PR TITLE
Update model state when renaming a file

### DIFF
--- a/autoload/markbar/MarkbarModel.vim
+++ b/autoload/markbar/MarkbarModel.vim
@@ -172,6 +172,14 @@ function! markbar#MarkbarModel#pushNewBuffer(buffer_no) abort dict
 endfunction
 let s:MarkbarModel.pushNewBuffer = function('markbar#MarkbarModel#pushNewBuffer')
 
+" DETAILS:  Update model state to reflect a file being renamed.
+function! markbar#MarkbarModel#changeFilename(old_filepath, new_filepath) abort dict
+    call markbar#ensure#IsString(a:old_filepath)
+    call markbar#ensure#IsString(a:new_filepath)
+    call l:self._rosters.cloneRosterToNewName(a:old_filepath, a:new_filepath)
+endfunction
+let s:MarkbarModel.changeFilename = function('markbar#MarkbarModel#changeFilename')
+
 " RETURNS:  (markbar#MarkData)  The MarkData object corresponding to the given
 "                               mark character.
 " DETAILS:  - If the requested mark is a local mark, then the MarkbarModel

--- a/autoload/markbar/ShaDaRosters.vim
+++ b/autoload/markbar/ShaDaRosters.vim
@@ -137,15 +137,14 @@ function! markbar#ShaDaRosters#getName(filepath, mark_char) abort dict
 endfunction
 let s:ShaDaRosters.getName = function('markbar#ShaDaRosters#getName')
 
-" DETAILS:  Change the filename for a given local roster.
+" DETAILS:  Clone a given local roster to a new filename.
 "           - The global roster cannot be modified in this way.
 "           - {old_filepath} and {new_filepath} must be strings.
-function! markbar#ShaDaRosters#changeRosterFilename(old_filepath,
+function! markbar#ShaDaRosters#cloneRosterToNewName(old_filepath,
                                                   \ new_filepath) abort dict
     call markbar#ensure#IsString(a:old_filepath)
     call markbar#ensure#IsString(a:new_filepath)
-    let l:roster = l:self.rosterFor(a:old_filepath)
-    call remove(l:self._filepaths_to_rosters, a:old_filepath)
+    let l:roster = deepcopy(l:self.rosterFor(a:old_filepath))
     let l:self._filepaths_to_rosters[a:new_filepath] = l:roster
 endfunction
-let s:ShaDaRosters.changeRosterFilename = function('markbar#ShaDaRosters#changeRosterFilename')
+let s:ShaDaRosters.cloneRosterToNewName = function('markbar#ShaDaRosters#cloneRosterToNewName')

--- a/plugin/vim-markbar.vim
+++ b/plugin/vim-markbar.vim
@@ -410,4 +410,7 @@ augroup markbar_model_update
     autocmd BufEnter * call g:markbar_model.pushNewBuffer(expand('<abuf>') + 0)
     autocmd BufDelete,BufWipeout *
         \ call g:markbar_model.evictBufferCache(expand('<abuf>') + 0)
+    autocmd BufFilePre * let g:markbar_old_bufname = expand('%:p')
+    autocmd BufFilePost * call g:markbar_model.changeFilename(
+        \ g:markbar_old_bufname, expand('%:p'))
 augroup end

--- a/test/standalone-test-sequential-name-persistence.vader/03-standalone-test-sequential-name-persistence.vader
+++ b/test/standalone-test-sequential-name-persistence.vader/03-standalone-test-sequential-name-persistence.vader
@@ -41,7 +41,6 @@ Expect (Names from original file are preserved):
 
 Execute (Rename and move the mark in the new file):
   edit standalone-test-sequential-name-persistence.vader/thirtylines.temp
-  call g:markbar_model.renameMark('a', 'thirtylines a')
   call g:markbar_model.renameMark('c', 'thirtylines c')
   call g:markbar_model.renameMark('B', 'thirtylines B')
   normal! 10G08lma
@@ -49,7 +48,7 @@ Execute (Rename and move the mark in the new file):
   normal Mo
 Expect (Names are changed):
   " Press ? for help
-  ['a]: (l: 10, c: 9) thirtylines a
+  ['a]: (l: 10, c: 9) 30lines.txt a
   ['b]: (l: 30, c: 3)
   ['c]: (l: 10, c: 6) thirtylines c
   ['A]: 10lines.txt A 10lines.txt [l: 1, c: 6]

--- a/test/standalone-test-sequential-name-persistence.vader/04-standalone-test-sequential-name-persistence.vader
+++ b/test/standalone-test-sequential-name-persistence.vader/04-standalone-test-sequential-name-persistence.vader
@@ -10,3 +10,15 @@ Expect (Old mark names from before are preserved):
   ['A]: 10lines.txt A 10lines.txt [l: 1, c: 6]
   ['B]: thirtylines B standalone-test-sequential-name-persistence.vader/thirtylines.temp [l: 15, c: 5]
   ['C]: standalone-test-sequential-name-persistence.vader/thirtylines.temp [l: 25, c: 8]
+
+Execute (Reopen thirtylines.temp):
+  edit standalone-test-sequential-name-persistence.vader/thirtylines.temp
+  normal Mo
+Expect (Old mark names from before are preserved):
+  " Press ? for help
+  ['a]: (l: 10, c: 9) 30lines.txt a
+  ['b]: (l: 30, c: 3)
+  ['c]: (l: 10, c: 6) thirtylines c
+  ['A]: 10lines.txt A 10lines.txt [l: 1, c: 6]
+  ['B]: thirtylines B standalone-test-sequential-name-persistence.vader/thirtylines.temp [l: 15, c: 5]
+  ['C]: standalone-test-sequential-name-persistence.vader/thirtylines.temp [l: 25, c: 8]

--- a/test/test-ShaDaRosters.vader
+++ b/test/test-ShaDaRosters.vader
@@ -33,16 +33,28 @@ Then:
     endfor
   endfor
 
-Execute (ShaDaRosters changes roster filenames properly):
-  call g:rosters.changeRosterFilename('/foo/baz.txt', '/foo/quoz.txt')
+Execute (ShaDaRosters clones rosters properly):
+  call g:rosters.cloneRosterToNewName('/foo/baz.txt', '/foo/quoz.txt')
   let g:new_globals = {}
   let g:new_filepaths_to_local_rosters = {}
   call g:rosters.writeRosters(['/foo/baz.txt', '/foo/quoz.txt'],
       \ g:new_globals, g:new_filepaths_to_local_rosters)
 Then:
   AssertEqual g:global_roster, g:new_globals
-  AssertEqual 1, len(g:new_filepaths_to_local_rosters)
+  AssertEqual 2, len(g:new_filepaths_to_local_rosters)
   AssertEqual g:filepaths_to_local_rosters['/foo/baz.txt'],
+      \ g:new_filepaths_to_local_rosters['/foo/baz.txt']
+  AssertEqual g:filepaths_to_local_rosters['/foo/baz.txt'],
+      \ g:new_filepaths_to_local_rosters['/foo/quoz.txt']
+
+Execute (Cloned rosters are not references to the old roster):
+  call g:rosters.setName('/foo/quoz.txt', 'd', 'd')
+  call g:rosters.writeRosters(['/foo/baz.txt', '/foo/quoz.txt'],
+      \ g:new_globals, g:new_filepaths_to_local_rosters)
+Then:
+  AssertEqual g:filepaths_to_local_rosters['/foo/baz.txt'],
+      \ g:new_filepaths_to_local_rosters['/foo/baz.txt']
+  AssertEqual {'d': 'd', 'e': 'mark e', 'f': 'mark f'},
       \ g:new_filepaths_to_local_rosters['/foo/quoz.txt']
 
 Execute (ShaDaRosters throws when given global marks and a filepath):


### PR DESCRIPTION
ShaDaRosters weren't being updated when buffer names were changed with
:saveas or :file. Do that.