### PR TITLE
Improve compatibility for Neovim 0.3.x

### DIFF
--- a/autoload/markbar/settings.vim
+++ b/autoload/markbar/settings.vim
@@ -28,7 +28,7 @@ function! markbar#settings#PersistMarkNames() abort
     if !exists('g:markbar_persist_mark_names')
         let g:markbar_persist_mark_names = v:true
     endif
-    if (has('nvim') && &shadafile ==# 'NONE') ||
+    if (has('nvim-0.4') && &shadafile ==# 'NONE') ||
             \ (!has('nvim') && &viminfofile ==# 'NONE')
         let g:markbar_persist_mark_names = v:false
     endif


### PR DESCRIPTION
Legacy Neovim has the option `&shada`, but not `&shadafile`.
So this patch fixes the following problem:

    Error detected while processing function MarkbarVimEnter[6]..markbar#settings#PersistMarkNames:
    line    4:
    E113: Unknown option: shadafile
