### PR TITLE
Add support for manually writing/reading mark names from ShaDa/viminfo

### DIFF
--- a/.travis_vimrc
+++ b/.travis_vimrc
@@ -30,6 +30,9 @@ endif
 
 map <Leader>m <Plug>ToggleMarkbar
 
+map <Leader>rrr <Plug>ReadMarkbarRosters
+map <Leader>www <Plug>WriteMarkbarRosters
+
 map Mo <Plug>OpenMarkbar
 map Mc <Plug>CloseMarkbar
 map Mt <Plug>ToggleMarkbar

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Features
 - **Jump to marks** directly from the markbar.
 - **Open automatically on `` ` `` or `'`,** _à la_ [vim-peekaboo!](https://github.com/junegunn/vim-peekaboo)
 - **Assign names** to your marks that persist between vim sessions!
+- **(WIP) Synchronize those names** between concurrent vim instances!
 - **Heavily customizable!** See below for details.
 
 Requirements
@@ -87,6 +88,20 @@ if has('nvim')
 else
     set viminfo+=!
 endif
+" let g:markbar_persist_mark_names = v:true
+
+
+" this lets you write your custom mark names to ShaDa/viminfo on demand,
+" rather than waiting until you :q to exit. That lets you sync mark names
+" between (neo)vim editor instances without closing and reopening vim.
+"
+" this and the mapping below will trigger wshada[!]/wviminfo[!] and
+" rshada[!]/rviminfo[!]. trigger this after setting custom mark names
+nmap <Leader>www <Plug>WriteMarkbarRosters
+
+" trigger this mapping in other vim instances to update the mark names in
+" their markbars
+nmap <Leader>rrr <Plug>ReadMarkbarRosters
 ```
 
 These examples use the [leader key,](https://stackoverflow.com/questions/1764263/what-is-the-leader-in-a-vimrc-file)

--- a/autoload/markbar/BufferCache.vim
+++ b/autoload/markbar/BufferCache.vim
@@ -15,6 +15,7 @@ let s:BufferCache = {
 " PARAM:    rosters     (ShaDaRosters)  Mark names from/for the ShaDa file.
 function! markbar#BufferCache#New(buffer_no, rosters) abort
     call markbar#ensure#IsNumber(a:buffer_no)
+    call markbar#ensure#IsClass(a:rosters, 'ShaDaRosters')
     let l:new = deepcopy(s:BufferCache)
     let l:new._buffer_no = a:buffer_no
     let l:new._rosters = a:rosters
@@ -55,7 +56,7 @@ function! markbar#BufferCache#updateCache(marks_and_getpos, bufname,
     let l:new_marks_dict = {}
     for [l:mark_char, l:getpos] in items(a:marks_and_getpos)
         let l:markdata = markbar#MarkData#New(l:mark_char, l:getpos, a:bufname,
-                                            \ a:filepath)
+                                            \ a:filepath, l:self._rosters)
         let l:new_marks_dict[l:mark_char] = l:markdata
     endfor
 
@@ -76,14 +77,6 @@ function! markbar#BufferCache#updateCache(marks_and_getpos, bufname,
     " We assert that the names in l:self._rosters at this point are not
     " 'stale': they've either been cleared while iterating over l:old_dict,
     " or cleared/renamed by a call to g:markbar_model.delete/reset/renameMark()
-
-    " iterate over current marks, set names from rosters
-    for [l:mark, l:mark_data] in items(l:new_marks_dict)
-        if empty(l:mark_data.getUserName())
-            let l:old_name = l:self._rosters.getName(l:roster_key, l:mark)
-            call l:mark_data.setUserName(l:old_name)
-        endif
-    endfor
 
     let l:self.marks_dict = l:new_marks_dict
 endfunction

--- a/autoload/markbar/settings.vim
+++ b/autoload/markbar/settings.vim
@@ -63,6 +63,18 @@ function! markbar#settings#PersistMarkNames() abort
     return g:markbar_persist_mark_names
 endfunction
 
+function! markbar#settings#PrintTimeOnShaDaIO() abort
+    if !exists('g:markbar_print_time_on_shada_io')
+        let g:markbar_print_time_on_shada_io = v:true
+    endif
+    call s:AssertType(
+        \ g:markbar_print_time_on_shada_io,
+        \ v:t_bool,
+        \ 'g:markbar_print_time_on_shada_io'
+    \ )
+    return g:markbar_print_time_on_shada_io
+endfunction
+
 " RETURNS:  (v:t_bool)      Whether to open the fold(s) in which a mark is
 "                           located, if any.
 function! markbar#settings#foldopen() abort

--- a/doc/vim-markbar.txt
+++ b/doc/vim-markbar.txt
@@ -128,6 +128,13 @@ For options unique to the "peekaboo" markbar, see |vim-markbar-peekaboo-options|
 
     See |vim-markbar-rename-mark|.
 
+*g:markbar_print_time_on_shada_io*                       |(v:t_bool)|
+    `Default Value: v:true`
+
+    Whether to |echomsg| things like "vim-markbar serialized and wrote mark
+    rosters at Wed Aug 23rd..." when vim-markbar reads or writes from |shada|
+    (in neovim) or |viminfo| (in vim).
+
 *g:markbar_foldopen*                                     |(v:t_bool)|
     `Default Value`: (set from the 'foldopen' option, see `:help fdo`)
 

--- a/plugin/vim-markbar.vim
+++ b/plugin/vim-markbar.vim
@@ -55,12 +55,27 @@ let g:markbar_standard_controller =
         \ markbar#MarkbarController#New(g:markbar_model, g:markbar_view,
                                       \ g:markbar_standard_format)
 
-function! g:MarkbarPopulateRosters() abort
-    if has('nvim')
-        rshada
-    else
-        rviminfo
+function! g:MarkbarPopulateRosters(...) abort
+    let l:is_startup = v:false
+    if a:0
+        call markbar#ensure#IsBoolean(l:is_startup)
+        let l:is_startup = a:1
     endif
+
+    " This rshada/rviminfo breaks tests.
+    "     Vim(rshada):E886: System error while opening ShaDa file
+    "     standalone-test-sequential-name-persistence.vader/viminfo_or_shada for
+    "     reading: no such file or directory
+    " Kludge: don't run this block when called from g:MarkbarVimEnter()
+    " {
+    if !l:is_startup
+        if has('nvim')
+            rshada
+        else
+            rviminfo
+        endif
+    endif
+    " } end
 
     if !exists('g:MARKBAR_GLOBAL_ROSTER')
         let g:MARKBAR_GLOBAL_ROSTER = '{}'
@@ -118,7 +133,7 @@ function! g:MarkbarVimEnter() abort
         return
     endif
     if markbar#settings#PersistMarkNames()
-        call g:MarkbarPopulateRosters()
+        call g:MarkbarPopulateRosters(v:true)
     endif
 
     " catching /Buffer not cached/ in MarkbarController.refreshContents()

--- a/plugin/vim-markbar.vim
+++ b/plugin/vim-markbar.vim
@@ -86,6 +86,10 @@ function! g:MarkbarPopulateRosters(...) abort
     let l:global_roster = json_decode(g:MARKBAR_GLOBAL_ROSTER)
     let l:local_rosters = json_decode(g:MARKBAR_LOCAL_ROSTERS)
     call g:markbar_rosters.populate(l:global_roster, l:local_rosters)
+
+    " TODO: setting for whether to print this.
+    echomsg printf('vim-markbar read and populated mark rosters at %s.',
+                 \ strftime('%c'))
 endfunction
 
 function! g:MarkbarSerializeRosters() abort
@@ -112,6 +116,10 @@ function! g:MarkbarSerializeRosters() abort
     else
         wviminfo
     endif
+
+    " TODO: setting for whether to print this.
+    echomsg printf('vim-markbar serialized and wrote mark rosters at %s.',
+                 \ strftime('%c'))
 endfunction
 
 ""

--- a/plugin/vim-markbar.vim
+++ b/plugin/vim-markbar.vim
@@ -87,9 +87,10 @@ function! g:MarkbarPopulateRosters(...) abort
     let l:local_rosters = json_decode(g:MARKBAR_LOCAL_ROSTERS)
     call g:markbar_rosters.populate(l:global_roster, l:local_rosters)
 
-    " TODO: setting for whether to print this.
-    echomsg printf('vim-markbar read and populated mark rosters at %s.',
-                 \ strftime('%c'))
+    if markbar#settings#PrintTimeOnShaDaIO()
+        echomsg printf('vim-markbar read and populated mark rosters at %s.',
+                     \ strftime('%c'))
+    endif
 endfunction
 
 function! g:MarkbarSerializeRosters() abort
@@ -117,9 +118,10 @@ function! g:MarkbarSerializeRosters() abort
         wviminfo
     endif
 
-    " TODO: setting for whether to print this.
-    echomsg printf('vim-markbar serialized and wrote mark rosters at %s.',
-                 \ strftime('%c'))
+    if markbar#settings#PrintTimeOnShaDaIO()
+        echomsg printf('vim-markbar serialized and wrote mark rosters at %s.',
+                     \ strftime('%c'))
+    endif
 endfunction
 
 ""

--- a/plugin/vim-markbar.vim
+++ b/plugin/vim-markbar.vim
@@ -55,7 +55,13 @@ let g:markbar_standard_controller =
         \ markbar#MarkbarController#New(g:markbar_model, g:markbar_view,
                                       \ g:markbar_standard_format)
 
-function! s:PopulateRosters() abort
+function! g:MarkbarPopulateRosters() abort
+    if has('nvim')
+        rshada
+    else
+        rviminfo
+    endif
+
     if !exists('g:MARKBAR_GLOBAL_ROSTER')
         let g:MARKBAR_GLOBAL_ROSTER = '{}'
     endif
@@ -67,7 +73,7 @@ function! s:PopulateRosters() abort
     call g:markbar_rosters.populate(l:global_roster, l:local_rosters)
 endfunction
 
-function! s:SerializeRosters() abort
+function! g:MarkbarSerializeRosters() abort
     " update v:oldfiles with the files whose marks will be recorded in
     " shada or viminfo
     if has('nvim')
@@ -112,7 +118,7 @@ function! g:MarkbarVimEnter() abort
         return
     endif
     if markbar#settings#PersistMarkNames()
-        call s:PopulateRosters()
+        call g:MarkbarPopulateRosters()
     endif
 
     " catching /Buffer not cached/ in MarkbarController.refreshContents()
@@ -132,7 +138,7 @@ function! s:MarkbarVimLeave() abort
         let l:persist_mark_names = v:false
     endtry
     if l:persist_mark_names
-        call s:SerializeRosters()
+        call g:MarkbarSerializeRosters()
     endif
 endfunction
 
@@ -169,6 +175,9 @@ endfunction
 noremap <silent> <Plug>OpenMarkbar      :call <SID>OpenMarkbar()<cr>
 noremap <silent> <Plug>CloseMarkbar     :call <SID>CloseMarkbar()<cr>
 noremap <silent> <Plug>ToggleMarkbar    :call <SID>ToggleMarkbar()<cr>
+
+nnoremap <silent> <Plug>ReadMarkbarRosters  :call g:MarkbarPopulateRosters()<cr>
+nnoremap <silent> <Plug>WriteMarkbarRosters :call g:MarkbarSerializeRosters()<cr>
 
 function! s:SetMarkbarMappings() abort
     mapclear <buffer>

--- a/test/README.md
+++ b/test/README.md
@@ -70,7 +70,7 @@ a subdirectory are each run in separate (n)vim instances, one after the other in
 ascending numerical order, and share the same initially empty viminfo/shada file
 with each other.
 
-Other Notes
+Other Notes and Known Issues
 --------------------------------------------------------------------------------
 vader.vim is sensitive to trailing whitespace in its `Expect:` blocks, where
 they denote an empty line in the buffer. Some tests (particularly
@@ -79,3 +79,7 @@ and [standalone-test-peekaboo.vader](./standalone-test-peekaboo.vader)) rely on
 this behavior. If you use vim autocommands to automatically delete trailing
 whitespace on buffer write, then you should disable those autocommands when
 editing vader files.
+
+Test output from running `run_tests.sh` with a vim executable is significantly
+slower than with neovim and is badly mangled because the running vim instance
+doesn't respect the actual size of the terminal window. See [Issue #53](https://github.com/Yilin-Yang/vim-markbar/issues/53).

--- a/test/test-MarkData.vader
+++ b/test/test-MarkData.vader
@@ -1,6 +1,6 @@
 Execute (MarkData constructs local alphabetic marks properly):
   let g:result = markbar#MarkData#New('a', [0, 97, 1, 0], 'foobar.txt',
-                                    \ '/foo/bar/foobar.txt')
+                                    \ '/foo/bar/foobar.txt', g:markbar_rosters)
 Then:
   AssertEqual 'MarkData', g:result['TYPE']
   AssertEqual 'a',  g:result.getMarkChar()
@@ -10,7 +10,7 @@ Then:
 
 Execute (MarkData constructs non-alphabetic marks properly):
   let g:result = markbar#MarkData#New('[', [0, 1, 1, 0], 'foobar.txt',
-                                    \ '/foo/bar/foobar.txt')
+                                    \ '/foo/bar/foobar.txt', g:markbar_rosters)
 Then:
   AssertEqual 'MarkData', g:result['TYPE']
   AssertEqual '[', g:result.getMarkChar()
@@ -21,10 +21,10 @@ Then:
 Execute (MarkData constructs [, ] marks properly):
   let left_bracket =
     \ markbar#MarkData#New('[', [0, 1, 1, 0], 'foobar.txt',
-                         \ '/foo/bar/foobar.txt')
+                         \ '/foo/bar/foobar.txt', g:markbar_rosters)
   let right_bracket =
     \ markbar#MarkData#New(']', [0, 1, 5, 0], 'foobar.txt',
-                         \ '/foo/bar/foobar.txt')
+                         \ '/foo/bar/foobar.txt', g:markbar_rosters)
 Then:
   AssertEqual 'MarkData', g:result['TYPE']
   AssertEqual '[', left_bracket.getMarkChar()
@@ -40,7 +40,7 @@ Then:
 
 Execute (MarkData constructs global file marks properly):
   let g:result = markbar#MarkData#New('D', [0, 64, 31, 0], 'foobar.txt',
-                                    \ '/foo/bar/foobar.txt')
+                                    \ '/foo/bar/foobar.txt', g:markbar_rosters)
 Then:
   AssertEqual 'MarkData', g:result['TYPE']
   AssertEqual 'D',  g:result.getMarkChar()
@@ -50,7 +50,7 @@ Then:
 
 Execute (MarkData constructs numeric marks properly):
   let g:result = markbar#MarkData#New('8', [0, 19, 5, 0], 'foobar.txt',
-                                    \ '/foo/bar/foobar.txt')
+                                    \ '/foo/bar/foobar.txt', g:markbar_rosters)
 Then:
   AssertEqual 'MarkData', g:result['TYPE']
   AssertEqual '8',  g:result.getMarkChar()
@@ -60,13 +60,13 @@ Then:
 
 Execute (MarkData throws when constructed with non-positive line or column number):
   AssertThrows markbar#MarkData#New('D', [0, 0, 1, 0], 'foobar.txt',
-                                  \ '/foo/bar/foobar.txt')
+                                  \ '/foo/bar/foobar.txt', g:markbar_rosters)
   AssertThrows markbar#MarkData#New('D', [0, 1, 0, 0], 'foobar.txt',
-                                  \ '/foo/bar/foobar.txt')
+                                  \ '/foo/bar/foobar.txt', g:markbar_rosters)
 
 Execute (MarkData throws when given badly formatted getpos output):
   AssertThrows markbar#MarkData#New('D', [0, 1, 0], 'foobar.txt',
-                                  \ '/foo/bar/foobar.txt')
+                                  \ '/foo/bar/foobar.txt', g:markbar_rosters)
 
 Execute (MarkData gives proper names to "punctuation marks"):
   let g:marks_and_names = [
@@ -85,6 +85,6 @@ Execute (MarkData gives proper names to "punctuation marks"):
   \ ]
   for [g:mark, g:name] in g:marks_and_names
     let g:markdata = markbar#MarkData#New(g:mark, [0, 1, 2, 0],
-        \ 'foobar.txt', '/foo/bar/foobar.txt')
+        \ 'foobar.txt', '/foo/bar/foobar.txt', g:markbar_rosters)
     AssertEqual g:name, g:markdata.getDefaultName()
   endfor

--- a/test/test-MarkbarTextGenerator.vader
+++ b/test/test-MarkbarTextGenerator.vader
@@ -47,7 +47,8 @@ Execute (MarkbarTextGenerator prints no marks with empty 'marks_to_display'):
   function! SynthesizeMark(mark_char, line_no, col_no, bufname,
                          \ filename, context) abort
     let l:mark = markbar#MarkData#New(
-        \ a:mark_char, [0, a:line_no, a:col_no, 0], a:bufname, a:filename)
+        \ a:mark_char, [0, a:line_no, a:col_no, 0], a:bufname, a:filename,
+        \ g:markbar_rosters)
     call l:mark.setContext(a:context)
     let l:mark.getFilename = function({a -> a}, [a:filename])
     return l:mark


### PR DESCRIPTION
Partly addresses #52. This lets the user manually write (with a plugin mapping) all of their mark names into ShaDa/viminfo and then manually read (with a plugin mapping) all of those mark names into the markbar of another vim instance.

Other data, like the actual locations of the marks or whether they've been deleted, are not synchronized.

**Have not yet written tests for this** because that would require running two (neo)vim test instances at the same time.