### PR TITLE
Document persistent mark names clobbering viminfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,15 @@ which mark to jump to.
 If you want to disable the peekaboo markbar entirely, you can set
 `g:markbar_enable_peekaboo` to `v:false`.
 
+When using vim (not neovim) with `g:markbar_persist_mark_names` set to `v:true`,
+vim-markbar will reorder and clobber the timestamps of your command, search
+string, expression, etc. history in your `.viminfo` file. (See [Issue #56](https://github.com/Yilin-Yang/vim-markbar/issues/56).)
+This may change the order of the command history that you see after typing `:`
+and using the Up and Down arrow keys. Unfortunately, the only way to fix this
+(while still using vim) is to set `g:markbar_persist_mark_names` to `v:false`,
+which will prevent you from setting mark names that persist between editor
+sessions. neovim users won't experience this issue.
+
 ### Mark Header Customization
 vim-markbar shows a header for each mark. In addition to a name set by the
 user, the default header consists of basic information about the mark,

--- a/doc/vim-markbar.txt
+++ b/doc/vim-markbar.txt
@@ -126,6 +126,11 @@ For options unique to the "peekaboo" markbar, see |vim-markbar-peekaboo-options|
 
     Requires |viminfo-!| (in vim) or |shada-!| (in neovim) to work properly.
 
+    A known issue (Issue #56 on GitHub) is that setting this to `v:true` may
+    reorder your command history after closing and reopening vim. (This only
+    affects vim, not neovim.) Unfortunately, the only way to fix this (without
+    switching to neovim) is to set this option to `v:false`.
+
     See |vim-markbar-rename-mark|.
 
 *g:markbar_print_time_on_shada_io*                       |(v:t_bool)|


### PR DESCRIPTION
Setting g:markbar_persist_mark_names to v:true causes vim (not neovim) to clobber timestamps and reorder history in the viminfo file, ref: Issue #56. Unfortunately, this can't be fixed without entirely breaking persistent mark names for vim users.

Document the issue in the README and help text.

Closes #56.