### PR TITLE
Optimize up markbar#helpers#FetchBufferLineRange()

### DIFF
--- a/autoload/markbar/MarkbarModel.vim
+++ b/autoload/markbar/MarkbarModel.vim
@@ -245,6 +245,10 @@ let s:MarkbarModel.evictBufferCache = function('markbar#MarkbarModel#evictBuffer
 "           they don't yet exist.
 function! markbar#MarkbarModel#updateCurrentAndGlobal() abort dict
     let l:bufnr = bufnr('%')
+    if getbufvar(l:bufnr, 'is_markbar')
+        " don't trigger model updates in the markbar itself
+        return
+    endif
     let l:cur_buffer_cache = l:self._getOrInitBufferCache(l:bufnr)
     "                                                     ^ This is bufnr('%')
     " and not getActiveBuffer() because helpers#GetLocalMarks() pulls |:marks|

--- a/autoload/markbar/helpers.vim
+++ b/autoload/markbar/helpers.vim
@@ -243,12 +243,14 @@ function! markbar#helpers#FetchBufferLineRange(buffer_expr, start, end) abort
     " between calls to this function
     let l:bufexists = bufexists(l:filename)
     let l:bufloaded = bufloaded(l:filename)
-    if l:bufexists && !l:bufloaded
+    let l:load_hidden_buffers = markbar#settings#CacheWithHiddenBuffers()
+    if !l:load_hidden_buffers && l:bufexists && !l:bufloaded
         " buffer may have been :bdelete'd or :bunload'd; respect user's wishes
         " and don't load the file again
         try
             let l:lines = readfile(l:filename, '',
                     \ markbar#settings#ReadfileMax())[a:start-1 : a:end-1]
+        catch
         endtry
     else
         silent execute 'tabnew ' . l:filename . ' | hide'

--- a/autoload/markbar/settings.vim
+++ b/autoload/markbar/settings.vim
@@ -319,6 +319,22 @@ function! markbar#settings#MaximumActiveBufferHistory() abort
     return g:markbar_maximum_active_buffer_history
 endfunction
 
+" RETURNS:  (v:t_number)    {max} parameter used in calls to |readfile()|.
+function! markbar#settings#ReadfileMax() abort
+    if !exists('g:markbar_readfile_max')
+        let g:markbar_readfile_max = 1000000
+    endif
+    call s:AssertType(
+        \ g:markbar_readfile_max,
+        \ v:t_number,
+        \ 'g:markbar_readfile_max'
+    \ )
+    if g:markbar_readfile_max <# 1
+        throw 'g:markbar_readfile_max must be at least 1.'
+    endif
+    return g:markbar_readfile_max
+endfunction
+
 " RETURNS:  (v:t_dict)  Dict holding the number of lines of context to be
 "                       retrieved around different kinds of marks, including
 "                       the line that holds the mark.

--- a/autoload/markbar/settings.vim
+++ b/autoload/markbar/settings.vim
@@ -24,6 +24,8 @@ function! markbar#settings#MarksToDisplay() abort
     return g:markbar_marks_to_display
 endfunction
 
+" RETURNS:  (v:t_bool)      Whether to preserve mark names between editor
+"                           sessions.
 function! markbar#settings#PersistMarkNames() abort
     if !exists('g:markbar_persist_mark_names')
         let g:markbar_persist_mark_names = v:true
@@ -63,6 +65,22 @@ function! markbar#settings#PersistMarkNames() abort
     return g:markbar_persist_mark_names
 endfunction
 
+" RETURNS:  (v:t_bool)      Whether to load unopened files containing marks
+"                           in hidden buffers to speed up context retrieval.
+function! markbar#settings#CacheWithHiddenBuffers() abort
+    if !exists('g:markbar_cache_with_hidden_buffers')
+        let g:markbar_cache_with_hidden_buffers = v:true
+    endif
+    call s:AssertType(
+        \ g:markbar_cache_with_hidden_buffers,
+        \ v:t_bool,
+        \ 'g:markbar_cache_with_hidden_buffers'
+    \ )
+    return g:markbar_cache_with_hidden_buffers
+endfunction
+
+" RETURNS:  (v:t_bool)      Whether to print messages when vim-markbar
+"                           serializes or deserializes mark rosters.
 function! markbar#settings#PrintTimeOnShaDaIO() abort
     if !exists('g:markbar_print_time_on_shada_io')
         let g:markbar_print_time_on_shada_io = v:false

--- a/doc/vim-markbar.txt
+++ b/doc/vim-markbar.txt
@@ -133,6 +133,15 @@ For options unique to the "peekaboo" markbar, see |vim-markbar-peekaboo-options|
 
     See |vim-markbar-rename-mark|.
 
+*g:markbar_cache_with_hidden_buffers*                    |(v:t_bool)|
+    `Default Value:` `v:true`
+
+    Whether to speed up context retrieval by loading unopened marked files in
+    hidden buffers. This effectively caches the file's contents between context
+    retrievals, making context retrieval faster. If this is turned off,
+    vim-markbar will retrieve context from unopened files by making calls to
+    |readfile()|, which can be much slower with very large files.
+
 *g:markbar_print_time_on_shada_io*                       |(v:t_bool)|
     `Default Value: v:false`
 
@@ -272,14 +281,15 @@ For options unique to the "peekaboo" markbar, see |vim-markbar-peekaboo-options|
     To retrieve context lines from files that the user hasn't explicitly opened,
     vim-markbar will load those files in hidden buffers in order to cache file
     contents between context retrievals. When a file has been opened and then
-    deleted or unloaded, vim-markbar will try to "respect" the |:bdelete| or
-    |:bunload| and will call |readfile()| instead of opening the file again
-    in a buffer. This can be very slow if the files being read are large. This
-    setting is the '{max}' parameter that vim-markbar will pass to |readfile()|
-    to limit the total number of lines retrieved.
+    deleted or unloaded while |g:markbar_cache_with_hidden_buffers| is
+    `v:false`, vim-markbar will try to "respect" the |:bdelete| or |:bunload|
+    and will call |readfile()| instead of opening the file again in a buffer.
+    This can be very slow if the files being read are large. This setting is the
+    '{max}' parameter that vim-markbar will pass to |readfile()| to limit the
+    total number of lines retrieved.
 
     Note that vim-markbar won't know if a buffer was destroyed by |:bwipeout|
-    and may try to open it in a hidden buffer.
+    and may try to open it again in a hidden buffer.
 
 *g:markbar_num_lines_context*                            |(varies)|
     `Default Value:` `5`

--- a/doc/vim-markbar.txt
+++ b/doc/vim-markbar.txt
@@ -266,6 +266,21 @@ For options unique to the "peekaboo" markbar, see |vim-markbar-peekaboo-options|
 
     There's probably no real reason to change this option.
 
+*g:markbar_readfile_max*                                 |(v:t_number)|
+    `Default Value:` `1000000`
+
+    To retrieve context lines from files that the user hasn't explicitly opened,
+    vim-markbar will load those files in hidden buffers in order to cache file
+    contents between context retrievals. When a file has been opened and then
+    deleted or unloaded, vim-markbar will try to "respect" the |:bdelete| or
+    |:bunload| and will call |readfile()| instead of opening the file again
+    in a buffer. This can be very slow if the files being read are large. This
+    setting is the '{max}' parameter that vim-markbar will pass to |readfile()|
+    to limit the total number of lines retrieved.
+
+    Note that vim-markbar won't know if a buffer was destroyed by |:bwipeout|
+    and may try to open it in a hidden buffer.
+
 *g:markbar_num_lines_context*                            |(varies)|
     `Default Value:` `5`
 
@@ -748,4 +763,3 @@ highlight group to use.  >
 
 
 ================================================================================
- vim:textwidth=80:filetype=help

--- a/test/standalone-test-FetchBufferLineRange.vader
+++ b/test/standalone-test-FetchBufferLineRange.vader
@@ -1,3 +1,6 @@
+Execute (Setup):
+  let g:markbar_cache_with_hidden_buffers = v:false
+
 Execute (FetchBufferLineRange works with bufhidden = unload):
   tabnew 50lines.txt
   set bufhidden=unload
@@ -51,6 +54,17 @@ Execute (FetchBufferLineRange works with bufhidden = hide):
   tabnew 50lines.txt
   set bufhidden=hide
   hide
+  let g:result = markbar#helpers#FetchBufferLineRange('*50lines.txt', 50, 50)
+Then:
+  let g:expected = ['fiftieth line']
+  AssertEqual g:expected, g:result
+
+Execute (FetchBufferLineRange respects g:markbar_cache_with_hidden_buffers):
+  let g:markbar_cache_with_hidden_buffers = v:true
+  tabnew 50lines.txt
+  set bufhidden=delete
+  hide
+  let g:markbar_readfile_max = 49
   let g:result = markbar#helpers#FetchBufferLineRange('*50lines.txt', 50, 50)
 Then:
   let g:expected = ['fiftieth line']

--- a/test/standalone-test-FetchBufferLineRange.vader
+++ b/test/standalone-test-FetchBufferLineRange.vader
@@ -1,0 +1,57 @@
+Execute (FetchBufferLineRange works with bufhidden = unload):
+  tabnew 50lines.txt
+  set bufhidden=unload
+  hide
+  let g:result = markbar#helpers#FetchBufferLineRange('*50lines.txt', 50, 50)
+Then:
+  let g:expected = ['fiftieth line']
+  AssertEqual g:expected, g:result
+
+Execute (FetchBufferLineRange works with bufhidden = delete):
+  tabnew 50lines.txt
+  set bufhidden=delete
+  hide
+  let g:result = markbar#helpers#FetchBufferLineRange('*50lines.txt', 50, 50)
+Then:
+  let g:expected = ['fiftieth line']
+  AssertEqual g:expected, g:result
+
+Execute (FetchBufferLineRange works with bufhidden = wipe):
+  tabnew 50lines.txt
+  set bufhidden=wipe
+  hide
+  let g:result = markbar#helpers#FetchBufferLineRange('*50lines.txt', 50, 50)
+Then:
+  let g:expected = ['fiftieth line']
+  AssertEqual g:expected, g:result
+
+Execute (FetchBufferLineRange respects g:markbar_readfile_max):
+  tabnew 50lines.txt
+  set bufhidden=delete
+  hide
+  let g:markbar_readfile_max = 49
+  let g:result = markbar#helpers#FetchBufferLineRange('*50lines.txt', 50, 50)
+Then:
+  let g:expected = []
+  AssertEqual g:expected, g:result
+
+Execute (FetchBufferLineRange works with empty bufhidden and nohidden):
+  tabnew 50lines.txt
+  set bufhidden=
+  set nohidden
+  hide
+  let g:result = markbar#helpers#FetchBufferLineRange('*50lines.txt', 50, 50)
+Then:
+  let g:expected = ['fiftieth line']
+  AssertEqual g:expected, g:result
+
+Execute (FetchBufferLineRange works with bufhidden = hide):
+  " NOTE: this must go last, otherwise 50lines.txt will be loaded in a buffer
+  " and no call to readfile() will take place
+  tabnew 50lines.txt
+  set bufhidden=hide
+  hide
+  let g:result = markbar#helpers#FetchBufferLineRange('*50lines.txt', 50, 50)
+Then:
+  let g:expected = ['fiftieth line']
+  AssertEqual g:expected, g:result

--- a/test/standalone-test-peekaboo.vader
+++ b/test/standalone-test-peekaboo.vader
@@ -65,10 +65,10 @@ Do (Set Marks, Peekaboo Markbar Open):
   1G05lmA5G0mB10G0mC
   '
 Then:
-  AssertEqual 0, &buflisted
+  AssertEqual 0, &buflisted, '&buflisted was not 0'
   AssertEqual 'nofile', &buftype
   AssertEqual 'hide', &bufhidden
-  AssertEqual 0, &swapfile
+  AssertEqual 0, &swapfile, '&swapfile was not 0'
   AssertEqual 'markbar', &filetype
   AssertEqual 'markbar', &syntax
   AssertEqual 1, b:is_markbar

--- a/test/test-fetchlines.vader
+++ b/test/test-fetchlines.vader
@@ -24,22 +24,28 @@ Before (Reload Test Files):
 # FetchBufferLineRange tests
 ################################################################################
 Execute (Get Beyond End of File):
-  let result = markbar#helpers#FetchBufferLineRange('*/1lines.txt', 1, 10)
+  let result = markbar#helpers#FetchBufferLineRange('*1lines.txt', 1, 10)
 Then:
   let expected = [
     \ 'first line',
   \ ]
   AssertEqual expected, result
 
+Execute (Get From Nonexistent File):
+  let result = markbar#helpers#FetchBufferLineRange('*foobar.txt', 1, 10)
+Then:
+  let expected = []
+  AssertEqual expected, result
+
 Execute (Get Entirely Beyond End of File):
-  let result = markbar#helpers#FetchBufferLineRange('*/1lines.txt', 3, 10)
+  let result = markbar#helpers#FetchBufferLineRange('*1lines.txt', 3, 10)
 Then:
   let expected = [
     \ ]
   AssertEqual expected, result
 
 Execute (Get Exactly One Line):
-  let result = markbar#helpers#FetchBufferLineRange('*/10lines.txt', 5, 5)
+  let result = markbar#helpers#FetchBufferLineRange('*10lines.txt', 5, 5)
 Then:
   let expected = [
     \ 'fifth line',
@@ -47,7 +53,7 @@ Then:
   AssertEqual expected, result
 
 Execute (Get Exactly Two Lines):
-  let result = markbar#helpers#FetchBufferLineRange('*/10lines.txt', 5, 6)
+  let result = markbar#helpers#FetchBufferLineRange('*10lines.txt', 5, 6)
 Then:
   let expected = [
     \ 'fifth line',
@@ -59,7 +65,7 @@ Then:
 Do (Modify File, Don't Write, Get From Unwritten Buffer):
   :edit! 10lines.txt\<cr>ggd4j\<esc>
 Then:
-  let result = markbar#helpers#FetchBufferLineRange('*/10lines.txt', 1, 5)
+  let result = markbar#helpers#FetchBufferLineRange('*10lines.txt', 1, 5)
   let expected = [
     \ 'sixth line',
     \ 'seventh line',
@@ -74,25 +80,25 @@ Then:
 # FetchContext tests
 ################################################################################
 Execute (Error Check: Non-Integer around_line):
-  AssertThrow call markbar#helpers#FetchContext('*/2lines.txt', 1.5, 2)
+  AssertThrow call markbar#helpers#FetchContext('*2lines.txt', 1.5, 2)
 
 Execute (Error Check: Non-Integer num_lines):
-  AssertThrow call markbar#helpers#FetchContext('*/2lines.txt', 1, 2.5)
+  AssertThrow call markbar#helpers#FetchContext('*2lines.txt', 1, 2.5)
 
 Execute (Error Check: Zero-valued around_line):
-  AssertThrow call markbar#helpers#FetchContext('*/2lines.txt', 0, 2)
+  AssertThrow call markbar#helpers#FetchContext('*2lines.txt', 0, 2)
 
 Execute (Get One-Line Context):
-  let result = markbar#helpers#FetchContext('*/2lines.txt', 2, 1)
+  let result = markbar#helpers#FetchContext('*2lines.txt', 2, 1)
 Then:
   let expected = ['second line']
   AssertEqual expected, result
 
 Execute (Get Zero-Sized Context):
-  AssertEqual [], markbar#helpers#FetchContext('*/10lines.txt', 1, 0)
+  AssertEqual [], markbar#helpers#FetchContext('*10lines.txt', 1, 0)
 
 Execute (Get Even-Sized Context):
-  let result = markbar#helpers#FetchContext('*/10lines.txt', 2, 4)
+  let result = markbar#helpers#FetchContext('*10lines.txt', 2, 4)
 Then:
   let expected = [
     \ 'first line',
@@ -103,7 +109,7 @@ Then:
   AssertEqual expected, result
 
 Execute (Get Odd-Sized Context):
-  let result = markbar#helpers#FetchContext('*/10lines.txt', 5, 5)
+  let result = markbar#helpers#FetchContext('*10lines.txt', 5, 5)
 Then:
   let expected = [
     \ 'third line',
@@ -115,7 +121,7 @@ Then:
   AssertEqual expected, result
 
 Execute (Get Context, Cut Off by Top of File):
-  let result = markbar#helpers#FetchContext('*/2lines.txt', 1, 3)
+  let result = markbar#helpers#FetchContext('*2lines.txt', 1, 3)
 Then:
   let expected = [
     \ '~',
@@ -125,7 +131,7 @@ Then:
   AssertEqual expected, result
 
 Execute (Get Context, Cut Off by Bottom of File):
-  let result = markbar#helpers#FetchContext('*/2lines.txt', 2, 3)
+  let result = markbar#helpers#FetchContext('*2lines.txt', 2, 3)
 Then:
   let expected = [
     \ 'first line',


### PR DESCRIPTION
Repeated calls to readfile() can be very slow when the marked files are very large. Cache file contents between FetchBufferLineRange() calls by loading the file in a hidden buffer. Only use readfile() when the user unloaded or deleted the buffer.

"Caching" a file will still be slow if the file is very, very large, but it seems necessary to pay that performance penalty if a user is editing and setting marks in a file that large.