### PR TITLE
Run `filetype detect` when caching files in hidden buffers

### DIFF
--- a/autoload/markbar/helpers.vim
+++ b/autoload/markbar/helpers.vim
@@ -253,7 +253,10 @@ function! markbar#helpers#FetchBufferLineRange(buffer_expr, start, end) abort
         catch
         endtry
     else
-        silent execute 'tabnew ' . l:filename . ' | hide'
+        " NOTE: without the `filetype detect`, filetype detection may not run
+        " in the opened buffer, and the lack of syntax highlighting might
+        " persist if the file is :edit'd by the user (ref: #59)
+        silent execute 'tabnew ' . l:filename . ' | filetype detect | hide'
         let l:lines = getbufline(l:filename, a:start, a:end)
     endif
 

--- a/test/README.md
+++ b/test/README.md
@@ -70,6 +70,26 @@ a subdirectory are each run in separate (n)vim instances, one after the other in
 ascending numerical order, and share the same initially empty viminfo/shada file
 with each other.
 
+A standalone sequential test need not exclusively consist of `*.vader` files.
+One can have a standalone sequential test with the folder structure:
+
+```
+standalone-test-sequential-something.vader/01-standalone-test-sequential-something.vader
+standalone-test-sequential-something.vader/02-standalone-test-sequential-something.sh
+standalone-test-sequential-something.vader/03-standalone-test-sequential-something.vader
+```
+
+In this folder, the `01-standalone-test-sequential-something.vader` test suite
+will run first, and then the `02-standalone-test-sequential-something.sh` bash
+script will run, followed by the `03-standalone-test-sequential-something.vader`
+test suite.
+
+Bash scripts in a standalone sequential test must take, as their first argument,
+the filepath of the vim executable being used to run the test; and as their
+second argument, "vim arguments" such as `-Nnu .test_vimrc`. See
+`standalone-test-sequential-filetype.vader` for an example. If the bash script
+returns a nonzero exit code, the test will fail.
+
 Other Notes and Known Issues
 --------------------------------------------------------------------------------
 vader.vim is sensitive to trailing whitespace in its `Expect:` blocks, where

--- a/test/standalone-test-sequential-filetype.vader/01-standalone-test-sequential-filetype.sh
+++ b/test/standalone-test-sequential-filetype.vader/01-standalone-test-sequential-filetype.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+VIM_EXE=$1
+VIM_ARGS=$2
+"$VIM_EXE" $VIM_ARGS ../README.md -c "q"
+exit 0

--- a/test/standalone-test-sequential-filetype.vader/02-standalone-test-sequential-filetype.sh
+++ b/test/standalone-test-sequential-filetype.vader/02-standalone-test-sequential-filetype.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+VIM_EXE=$1
+VIM_ARGS=$2
+# "$VIM_EXE" $VIM_ARGS -c 'call feedkeys(":edit ../README.md\<cr>", "n")' -c 'if &filetype !=# "markdown" | cquit! | else | quit | endif'
+# "$VIM_EXE" $VIM_ARGS -c 'call feedkeys(":edit ../README.md\<cr>", "n")' -c 'call feedkeys("i" . getbufvar("%", "&filetype"), "n")'
+# "$VIM_EXE" $VIM_ARGS -c 'call feedkeys(":edit ../README.md\<cr>", "n")' -c 'call feedkeys("i" . bufnr("%"), "n")'
+# "$VIM_EXE" $VIM_ARGS -c 'call feedkeys(":edit ../README.md\<cr>", "n")' -c 'autocmd VimEnter * call feedkeys("i" . bufnr("%"), "n")'
+"$VIM_EXE" $VIM_ARGS -c 'call feedkeys(":edit ../README.md\<cr>", "n")' -c 'call feedkeys(":if &filetype !=# \"markdown\" | cquit! | else | quit | endif\<cr>", "n")'
+# "$VIM_EXE" $VIM_ARGS -c 'call feedkeys(":edit ../README.md\<cr>", "n")' -c 'if v:false | cquit! | else | quit | endif'
+# "$VIM_EXE" $VIM_ARGS -c 'call feedkeys(":edit ../README.md\<cr>", "n")' -c 'echomsg &filetype'
+exit $?


### PR DESCRIPTION
When running the following steps, the given file will open without a detected filetype and without syntax highlighting:

1. Open foo.txt in vim (`nvim foo.txt`)
2. Exit vim.
3. Reopen vim (`nvim`)
4. Manually reload foo.txt (`:edit foo.txt`)

The issue arises because of this line in `markbar#helpers#FetchBufferLineRange()`:

    silent execute 'tabnew ' . l:filename . ' | hide'

Changing this to:

    silent execute 'tabnew ' . l:filename . ' | filetype detect | hide'

Fixes syntax highlighting.

Closes #59.
